### PR TITLE
Adding provider support for Groq/Whisper

### DIFF
--- a/src/transcription/api/groq.rs
+++ b/src/transcription/api/groq.rs
@@ -1,0 +1,118 @@
+//! Groq API implementation.
+//!
+//! Handles transcription requests to Groq's OpenAI-compatible Whisper API using multipart form data.
+
+use std::path::Path;
+use serde::Deserialize;
+
+use super::TranscriptionConfig;
+
+/// Groq API response wrapper
+#[derive(Debug, Deserialize)]
+struct GroqResponse {
+    text: String,
+}
+
+/// Transcribes an audio file using Groq's Whisper API.
+///
+/// Uses multipart form data with bearer token authentication.
+/// Groq provides an OpenAI-compatible API endpoint.
+/// 
+/// Keywords are passed as the `prompt` parameter to guide transcription context.
+pub async fn transcribe(
+    config: &TranscriptionConfig,
+    audio_path: &Path,
+) -> anyhow::Result<String> {
+    let audio_data = std::fs::read(audio_path).map_err(|e| {
+        anyhow::anyhow!("Failed to read audio file: {e}")
+    })?;
+
+    let client = reqwest::Client::new();
+
+    let file_name = audio_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let file_part = reqwest::multipart::Part::bytes(audio_data)
+        .file_name(file_name.clone())
+        .mime_str("audio/mpeg")
+        .map_err(|e| anyhow::anyhow!("Failed to create file part for upload: {e}"))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", file_part)
+        .text("model", config.model.api_model_name().to_string());
+
+    // Debug log: Log the API call details (without the audio data)
+    let mut debug_params = vec![
+        format!("model={}", config.model.api_model_name()),
+    ];
+
+    // Add keywords as prompt for better transcription context
+    if !config.keywords.is_empty() {
+        let prompt = config.keywords.join(", ");
+        form = form.text("prompt", prompt.clone());
+        debug_params.push(format!("prompt={prompt}"));
+        tracing::debug!("Keywords used as prompt for Groq model: {:?}", config.keywords);
+    }
+
+    let endpoint = config.model.endpoint();
+
+    tracing::debug!(
+        "Groq API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",
+        endpoint,
+        debug_params.join("\n    ")
+    );
+
+    let response = match client
+        .post(endpoint)
+        .bearer_auth(&config.api_key)
+        .multipart(form)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            let error_msg = if e.is_connect() {
+                "Failed to connect to Groq API server. Check your internet connection.".to_string()
+            } else if e.is_timeout() {
+                "Request to Groq timed out. The API server is not responding.".to_string()
+            } else if e.to_string().contains("builder") {
+                format!("Failed to build Groq API request: {e}. This may be a configuration error.")
+            } else {
+                format!("Groq network error: {e}")
+            };
+            return Err(anyhow::anyhow!(error_msg));
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_body = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+
+        let human_readable = match status.as_u16() {
+            401 => "Groq API key is invalid or expired. Please run 'ostt auth' to update your API key.".to_string(),
+            403 => "You don't have permission to use Groq's API. Check your API key and account status.".to_string(),
+            429 => "Too many requests to Groq. You've hit the API rate limit. Please wait and try again.".to_string(),
+            500 | 502 | 503 | 504 => "Groq API server is experiencing issues. Please try again later.".to_string(),
+            _ => format!("Groq API error (status {status}): {error_body}"),
+        };
+
+        return Err(anyhow::anyhow!(human_readable));
+    }
+
+    let groq_response: GroqResponse = response
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to parse Groq response: {e}"))?;
+
+    // Debug log: Log the full response for debugging
+    tracing::debug!(
+        "Groq API Response:\n  Status: Success\n  Transcription length: {} characters\n  Full response: {:#?}",
+        groq_response.text.len(),
+        groq_response
+    );
+
+    Ok(groq_response.text)
+}

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -7,6 +7,7 @@
 mod openai;
 mod deepgram;
 mod deepinfra;
+mod groq;
 
 use serde::Deserialize;
 use std::path::Path;
@@ -82,6 +83,9 @@ pub async fn transcribe(
         }
         TranscriptionProvider::DeepInfra => {
             deepinfra::transcribe(config, audio_path).await
+        }
+        TranscriptionProvider::Groq => {
+            groq::transcribe(config, audio_path).await
         }
     }?;
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -24,6 +24,10 @@ pub enum TranscriptionModel {
     DeepInfraWhisperLargeV3,
     /// DeepInfra Whisper Base model
     DeepInfraWhisperBase,
+    /// Groq Whisper Large V3 model
+    GroqWhisperLargeV3,
+    /// Groq Whisper Large V3 Turbo model (faster)
+    GroqWhisperLargeV3Turbo,
 }
 
 impl TranscriptionModel {
@@ -38,6 +42,8 @@ impl TranscriptionModel {
             }
             TranscriptionModel::DeepInfraWhisperLargeV3
             | TranscriptionModel::DeepInfraWhisperBase => TranscriptionProvider::DeepInfra,
+            TranscriptionModel::GroqWhisperLargeV3
+            | TranscriptionModel::GroqWhisperLargeV3Turbo => TranscriptionProvider::Groq,
         }
     }
 
@@ -51,6 +57,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepgramNova2 => "nova-2",
             TranscriptionModel::DeepInfraWhisperLargeV3 => "deepinfra-whisper-large-v3",
             TranscriptionModel::DeepInfraWhisperBase => "deepinfra-whisper-base",
+            TranscriptionModel::GroqWhisperLargeV3 => "groq-whisper-large-v3",
+            TranscriptionModel::GroqWhisperLargeV3Turbo => "groq-whisper-large-v3-turbo",
         }
     }
 
@@ -64,6 +72,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepgramNova2 => "Nova 2 (previous generation)",
             TranscriptionModel::DeepInfraWhisperLargeV3 => "Whisper Large V3 (best accuracy)",
             TranscriptionModel::DeepInfraWhisperBase => "Whisper Base (fast, lightweight)",
+            TranscriptionModel::GroqWhisperLargeV3 => "Whisper Large V3 (high accuracy)",
+            TranscriptionModel::GroqWhisperLargeV3Turbo => "Whisper Large V3 Turbo (fastest)",
         }
     }
 
@@ -78,6 +88,8 @@ impl TranscriptionModel {
             }
             TranscriptionModel::DeepInfraWhisperLargeV3
             | TranscriptionModel::DeepInfraWhisperBase => "https://api.deepinfra.com/v1/inference",
+            TranscriptionModel::GroqWhisperLargeV3
+            | TranscriptionModel::GroqWhisperLargeV3Turbo => "https://api.groq.com/openai/v1/audio/transcriptions",
         }
     }
 
@@ -91,6 +103,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepgramNova2 => "nova-2",
             TranscriptionModel::DeepInfraWhisperLargeV3 => "openai/whisper-large-v3",
             TranscriptionModel::DeepInfraWhisperBase => "openai/whisper-base",
+            TranscriptionModel::GroqWhisperLargeV3 => "whisper-large-v3",
+            TranscriptionModel::GroqWhisperLargeV3Turbo => "whisper-large-v3-turbo",
         }
     }
 
@@ -104,6 +118,8 @@ impl TranscriptionModel {
             "nova-2" => Some(TranscriptionModel::DeepgramNova2),
             "deepinfra-whisper-large-v3" => Some(TranscriptionModel::DeepInfraWhisperLargeV3),
             "deepinfra-whisper-base" => Some(TranscriptionModel::DeepInfraWhisperBase),
+            "groq-whisper-large-v3" => Some(TranscriptionModel::GroqWhisperLargeV3),
+            "groq-whisper-large-v3-turbo" => Some(TranscriptionModel::GroqWhisperLargeV3Turbo),
             _ => None,
         }
     }
@@ -118,6 +134,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepgramNova2,
             TranscriptionModel::DeepInfraWhisperLargeV3,
             TranscriptionModel::DeepInfraWhisperBase,
+            TranscriptionModel::GroqWhisperLargeV3,
+            TranscriptionModel::GroqWhisperLargeV3Turbo,
         ]
     }
 

--- a/src/transcription/provider.rs
+++ b/src/transcription/provider.rs
@@ -11,6 +11,7 @@ pub enum TranscriptionProvider {
     OpenAI,
     Deepgram,
     DeepInfra,
+    Groq,
 }
 
 impl TranscriptionProvider {
@@ -19,6 +20,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::OpenAI => "openai",
             TranscriptionProvider::Deepgram => "deepgram",
             TranscriptionProvider::DeepInfra => "deepinfra",
+            TranscriptionProvider::Groq => "groq",
         }
     }
 
@@ -27,6 +29,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::OpenAI => "OpenAI",
             TranscriptionProvider::Deepgram => "Deepgram",
             TranscriptionProvider::DeepInfra => "DeepInfra",
+            TranscriptionProvider::Groq => "Groq",
         }
     }
 
@@ -35,6 +38,7 @@ impl TranscriptionProvider {
             "openai" => Some(TranscriptionProvider::OpenAI),
             "deepgram" => Some(TranscriptionProvider::Deepgram),
             "deepinfra" => Some(TranscriptionProvider::DeepInfra),
+            "groq" => Some(TranscriptionProvider::Groq),
             _ => None,
         }
     }
@@ -44,6 +48,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::OpenAI,
             TranscriptionProvider::Deepgram,
             TranscriptionProvider::DeepInfra,
+            TranscriptionProvider::Groq,
         ]
     }
 }


### PR DESCRIPTION
## Summary
Add Groq as a transcription provider with support for two Whisper models:
- whisper-large-v3 - High accuracy model
- whisper-large-v3-turbo - Fastest model

## Changes
- Added Groq to TranscriptionProvider enum (src/transcription/provider.rs)
- Added GroqWhisperLargeV3 and GroqWhisperLargeV3Turbo to TranscriptionModel enum (src/transcription/model.rs)
- Implemented Groq API client using OpenAI-compatible endpoint (src/transcription/api/groq.rs)
- Integrated Groq provider into transcription routing (src/transcription/api/mod.rs)

## Technical Details
- API endpoint: https://api.groq.com/openai/v1/audio/transcriptions
- Authentication: Bearer token
- Request format: Multipart form data with file and model fields
- Supports optional prompt parameter for keyword guidance
- Consistent error handling and debug logging with existing providers