### PR TITLE
Add Frequency Spectrum Visualization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1229,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1404,6 +1422,7 @@ dependencies = [
  "ratatui",
  "reqwest",
  "rusqlite",
+ "rustfft",
  "serde",
  "signal-hook",
  "tokio",
@@ -1488,6 +1507,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1649,6 +1677,20 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -1917,6 +1959,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -2366,6 +2414,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tui-input = "0.14.0"
 # Audio capture and processing
 cpal = "0.16.0"
 hound = "3.5.1"
+rustfft = "6.2.0"
 
 # Async runtime
 tokio = { version = "1.48.0", features = ["full"] }

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -48,6 +48,12 @@ reference_level_db = -20
 # Add more formats as needed - ffmpeg handles the rest!
 output_format = "mp3 -ab 16k -ar 12000"
 
+# Visualization type for recording display
+# Options:
+#   "spectrum"  - Frequency spectrum showing energy across frequency bands (default)
+#   "waveform"  - Time-domain waveform showing amplitude over time
+visualization = "spectrum"
+
 # Provider-specific settings
 # Each provider can have its own configuration section
 

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -61,6 +61,7 @@ pub async fn handle_record() -> Result<(), anyhow::Error> {
         actual_sample_rate,
         config_data.audio.peak_volume_threshold,
         config_data.audio.reference_level_db,
+        config_data.audio.visualization,
     )
     .map_err(|e| anyhow::anyhow!("Failed to initialize UI: {e}"))?;
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -7,6 +7,31 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+/// Visualization type for recording display.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VisualizationType {
+    /// Time-domain waveform showing amplitude over time
+    Waveform,
+    /// Frequency spectrum showing energy distribution across frequencies
+    Spectrum,
+}
+
+impl Default for VisualizationType {
+    fn default() -> Self {
+        Self::Spectrum
+    }
+}
+
+impl std::fmt::Display for VisualizationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Waveform => write!(f, "waveform"),
+            Self::Spectrum => write!(f, "spectrum"),
+        }
+    }
+}
+
 /// Audio recording and processing configuration.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AudioConfig {
@@ -26,6 +51,9 @@ pub struct AudioConfig {
     /// Output audio format string: "codec [ffmpeg_options]" (e.g., "mp3 -ab 16k -ar 12000")
     #[serde(default = "default_output_format")]
     pub output_format: String,
+    /// Visualization type: "spectrum" (frequency-based) or "waveform" (time-based amplitude)
+    #[serde(default)]
+    pub visualization: VisualizationType,
 }
 
 fn default_output_format() -> String {
@@ -168,6 +196,7 @@ impl OsttConfig {
                 peak_volume_threshold: default_peak_volume_threshold(),
                 reference_level_db: default_reference_level_db(),
                 output_format: default_output_format(),
+                visualization: VisualizationType::default(),
             },
             providers: ProvidersConfig::default(),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,7 @@
 pub mod file;
 pub mod secrets;
 
-pub use file::{AudioConfig, OsttConfig};
+pub use file::{AudioConfig, OsttConfig, VisualizationType};
 pub use secrets::{clear_api_key, get_api_key, get_authorized_providers, save_api_key, save_selected_model, get_selected_model};
 
 pub use file::save_config;

--- a/src/recording/mod.rs
+++ b/src/recording/mod.rs
@@ -1,11 +1,12 @@
 //! Audio recording feature for ostt.
 //!
-//! Provides audio capture, real-time waveform visualization, and user interaction handling
+//! Provides audio capture, real-time visualization, and user interaction handling
 //! for the recording workflow.
 
 pub mod audio;
 pub mod ffmpeg;
 pub mod ui;
+pub mod visualizations;
 
 pub use audio::AudioRecorder;
 pub use ffmpeg::find_ffmpeg;

--- a/src/recording/visualizations/mod.rs
+++ b/src/recording/visualizations/mod.rs
@@ -1,0 +1,10 @@
+//! Visualization modules for recording display.
+//!
+//! Each module provides a different way to visualize audio during recording.
+//! New visualization types can be added by creating a new module here.
+
+pub mod spectrum;
+pub mod waveform;
+
+pub use spectrum::SpectrumAnalyzer;
+pub use waveform::{update_waveform, resize_waveform};

--- a/src/recording/visualizations/spectrum.rs
+++ b/src/recording/visualizations/spectrum.rs
@@ -1,0 +1,165 @@
+//! Frequency spectrum visualization using FFT.
+//!
+//! Displays audio energy distribution across frequency bands in the human voice range.
+
+use rustfft::{FftPlanner, num_complex::Complex};
+
+/// Stateful spectrum analyzer with internal FFT planner.
+pub struct SpectrumAnalyzer {
+    fft_planner: FftPlanner<f32>,
+    display_data: Vec<u64>,
+    num_bins: usize,
+}
+
+impl SpectrumAnalyzer {
+    /// Creates a new spectrum analyzer.
+    pub fn new(num_bins: usize) -> Self {
+        Self {
+            fft_planner: FftPlanner::new(),
+            display_data: vec![0u64; num_bins],
+            num_bins,
+        }
+    }
+
+    /// Updates spectrum with new samples, applying smoothing.
+    pub fn update(&mut self, samples: &[i16], sample_rate: u32, reference_level_db: i8) {
+        let new_bins = calculate_spectrum(
+            samples,
+            sample_rate,
+            self.num_bins,
+            reference_level_db,
+            &mut self.fft_planner,
+        );
+
+        // Apply moving average smoothing to reduce visual jitter
+        for (old_val, new_val) in self.display_data.iter_mut().zip(new_bins.iter()) {
+            *old_val = (*old_val + *new_val) / 2;
+        }
+    }
+
+    /// Resizes the analyzer for a new terminal width.
+    pub fn resize(&mut self, new_width: usize, samples: &[i16], sample_rate: u32, reference_level_db: i8) {
+        self.num_bins = new_width;
+        if !samples.is_empty() {
+            self.display_data = calculate_spectrum(
+                samples,
+                sample_rate,
+                self.num_bins,
+                reference_level_db,
+                &mut self.fft_planner,
+            );
+        } else {
+            self.display_data = vec![0u64; self.num_bins];
+        }
+    }
+
+    /// Returns the current display data.
+    pub fn data(&self) -> &[u64] {
+        &self.display_data
+    }
+}
+
+/// Calculates frequency spectrum from audio samples using FFT.
+///
+/// Returns magnitudes normalized to 0-100, matching volume meter scaling.
+/// Focuses on 100-1500 Hz (human voice fundamentals and harmonics).
+///
+/// # Arguments
+/// * `samples` - Audio samples (i16 PCM)
+/// * `sample_rate` - Audio sample rate in Hz
+/// * `num_bins` - Number of frequency bins to return (typically terminal width)
+/// * `reference_level_db` - Reference level for 100% display
+/// * `fft_planner` - Reusable FFT planner for performance
+pub fn calculate_spectrum(
+    samples: &[i16],
+    sample_rate: u32,
+    num_bins: usize,
+    reference_level_db: i8,
+    fft_planner: &mut FftPlanner<f32>,
+) -> Vec<u64> {
+    if samples.is_empty() {
+        return vec![0u64; num_bins];
+    }
+
+    let fft_size = 2048;
+    let sample_count = samples.len().min(fft_size);
+    let start_idx = samples.len().saturating_sub(sample_count);
+    let recent_samples = &samples[start_idx..];
+
+    // Apply Hanning window to reduce spectral leakage
+    let mut buffer: Vec<Complex<f32>> = recent_samples
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| {
+            let window = 0.5
+                * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / sample_count as f32).cos());
+            Complex::new(s as f32 * window / 32768.0, 0.0)
+        })
+        .collect();
+
+    buffer.resize(fft_size, Complex::new(0.0, 0.0));
+
+    let fft = fft_planner.plan_fft_forward(fft_size);
+    fft.process(&mut buffer);
+
+    let freq_resolution = sample_rate as f32 / fft_size as f32;
+
+    // Focus on core human voice range: 100-1500 Hz
+    let min_freq = 100.0;
+    let max_freq = 1500.0;
+
+    let min_bin = (min_freq / freq_resolution) as usize;
+    let max_bin = (max_freq / freq_resolution).min((fft_size / 2) as f32) as usize;
+
+    let noise_gate_db = reference_level_db as f32 - 35.0;
+
+    // Distribute FFT bins evenly across display width
+    let useful_bins = max_bin - min_bin;
+    let mut result = vec![0u64; num_bins];
+
+    for (display_idx, result_bin) in result.iter_mut().enumerate() {
+        let start_bin =
+            min_bin + ((display_idx * useful_bins) as f32 / num_bins as f32) as usize;
+        let end_bin = (min_bin
+            + (((display_idx + 1) * useful_bins) as f32 / num_bins as f32) as usize)
+            .min(max_bin)
+            .max(start_bin + 1);
+
+        if start_bin >= max_bin {
+            break;
+        }
+
+        let mut sum = 0.0;
+        let mut count = 0;
+        for bin_idx in start_bin..end_bin {
+            if bin_idx < buffer.len() / 2 {
+                sum += buffer[bin_idx].norm();
+                count += 1;
+            }
+        }
+
+        if count > 0 {
+            let avg_magnitude = sum / count as f32;
+
+            let db = if avg_magnitude > 1e-10 {
+                20.0 * avg_magnitude.log10()
+            } else {
+                -100.0
+            };
+
+            // Reduce by 20 dB to align FFT energy concentration with RMS volume
+            let adjusted_db = db - 20.0;
+
+            if adjusted_db < noise_gate_db {
+                *result_bin = 0;
+            } else {
+                let db_range = reference_level_db as f32 - noise_gate_db;
+                let normalized =
+                    ((adjusted_db - noise_gate_db) / db_range * 100.0).clamp(0.0, 100.0);
+                *result_bin = normalized as u64;
+            }
+        }
+    }
+
+    result
+}

--- a/src/recording/visualizations/waveform.rs
+++ b/src/recording/visualizations/waveform.rs
@@ -1,0 +1,36 @@
+//! Time-domain waveform visualization.
+//!
+//! Displays audio amplitude over time as a scrolling waveform.
+
+/// Updates waveform history with new volume sample.
+///
+/// Manages a scrolling buffer of volume values for time-domain display.
+///
+/// # Arguments
+/// * `history` - Mutable reference to volume history buffer
+/// * `current_volume` - Current volume (0-100)
+/// * `max_width` - Maximum width of display (terminal width)
+pub fn update_waveform(history: &mut Vec<u64>, current_volume: u8, max_width: usize) {
+    history.push(current_volume as u64);
+    
+    if history.len() > max_width {
+        history.remove(0);
+    }
+}
+
+/// Resizes waveform history to match terminal width.
+///
+/// # Arguments
+/// * `history` - Mutable reference to volume history buffer
+/// * `target_width` - New terminal width
+pub fn resize_waveform(history: &mut Vec<u64>, target_width: usize) {
+    if history.len() > target_width {
+        while history.len() > target_width {
+            history.remove(0);
+        }
+    } else if history.len() < target_width {
+        while history.len() < target_width {
+            history.insert(0, 0);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new frequency spectrum visualization mode using FFT analysis, providing real-time frequency distribution display optimized for human voice recording. Users can switch between the new spectrum mode and the original waveform mode via configuration.

## Key Features

### Frequency Spectrum Visualization
- FFT-based frequency analysis showing energy distribution across 100-1500 Hz (human voice range)
- Real-time display with smoothing to reduce visual jitter
- Aligns with volume meter scaling - spectrum peaks match volume peaks and red indicator
- Noise gating to suppress background noise (fridges, fans, etc.)

### Configurable Visualization Modes
- **Spectrum** (default): Shows frequency distribution - low voices on left, high voices on right
- **Waveform**: Original time-domain amplitude display

Configuration via `~/.config/ostt/ostt.toml`:
```toml
[audio]
visualization = "spectrum"  # or "waveform"
```

## Technical Implementation

### Modular Architecture
- Created `src/recording/visualizations/` module structure:
  - `spectrum.rs`: FFT-based frequency analysis with `SpectrumAnalyzer` struct
  - `waveform.rs`: Time-domain amplitude visualization
  - `mod.rs`: Public API exports
- Clean separation: UI code remains visualization-agnostic
- Extensible: New visualizations can be added by creating new modules

### Key Technical Details
- Uses 2048-sample FFT with Hanning window to reduce spectral leakage
- Focuses on 100-1500 Hz range (voice fundamentals and primary harmonics)
- Applies -20 dB adjustment to align FFT magnitude concentration with RMS volume
- Moving average smoothing for stable display
- Noise gate at `reference_level_db - 35 dB` to filter background noise

## Files Modified

- `src/config/file.rs`: Added `VisualizationType` enum
- `src/recording/ui.rs`: Refactored to support multiple visualization types
- `src/recording/visualizations/*`: New visualization modules
- `environments/ostt.toml`: Added visualization configuration
- `Cargo.toml`: Added `rustfft` dependency

## Dependencies

- Added `rustfft = "6.2.0"` for FFT calculations
