### PR TITLE
Add Nix flake for declarative builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Open Speech-to-Text recording tool with real-time volume metering and transcription";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        packages = {
+          ostt = pkgs.rustPlatform.buildRustPackage {
+            pname = "ostt";
+            version = "0.0.5";
+
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              makeWrapper
+            ];
+
+            buildInputs = with pkgs;
+              [
+                openssl
+                alsa-lib
+              ]
+              ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+                darwin.apple_sdk.frameworks.AudioUnit
+                darwin.apple_sdk.frameworks.CoreAudio
+                darwin.apple_sdk.frameworks.CoreFoundation
+              ];
+
+            postInstall = ''
+              wrapProgram $out/bin/ostt \
+                --prefix PATH : ${pkgs.lib.makeBinPath [
+                pkgs.ffmpeg
+                pkgs.wl-clipboard
+                pkgs.xclip
+              ]}
+            '';
+
+            meta = with pkgs.lib; {
+              description = "Open Speech-to-Text recording tool with real-time volume metering and transcription";
+              homepage = "https://github.com/kristoferlund/ostt";
+              license = licenses.mit;
+              maintainers = [];
+              mainProgram = "ostt";
+            };
+          };
+
+          default = self.packages.${system}.ostt;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            pkg-config
+            openssl
+            alsa-lib
+            ffmpeg
+            wl-clipboard
+            xclip
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
Adds a `flake.nix` for Nix users to build and install ostt declaratively.

- Uses `rustPlatform.buildRustPackage` for the Rust build
- Wraps binary with ffmpeg, wl-clipboard, xclip in PATH
- Supports both Linux (alsa-lib) and Darwin (AudioUnit/CoreAudio frameworks)
- Includes a dev shell for development

## Usage
```bash
# Run directly
nix run github:kristoferlund/ostt

# Install to profile
nix profile install github:kristoferlund/ostt

# Use as flake input
inputs.ostt.url = "github:kristoferlund/ostt";
```

## Test plan
- [x] `nix flake check` passes
- [x] `nix build` produces working binary
- [x] Binary runs and can authenticate/record