### PR TITLE
feat: add `ostt transcribe` command for pre-recorded audio files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Transcribe command** - Transcribe pre-recorded audio files without recording (`ostt transcribe <file>`). Supports the same output flags as `record` and `retry` (`-c` for clipboard, `-o` for file, stdout by default). Alias: `t`.
+
 ## 0.0.7 - 2026-02-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Transcribe command** - Transcribe pre-recorded audio files without recording (`ostt transcribe <file>`). Supports the same output flags as `record` and `retry` (`-c` for clipboard, `-o` for file, stdout by default). Alias: `t`.
+- **Transcribe command** - Transcribe pre-recorded audio files without recording (`ostt transcribe <file>`). Enables use of ostt's transcription pipeline in non-interactive workflows such as CI pipelines, GitHub Actions, or agentic scripts. Supports the same output flags as `record` and `retry` (`-c` for clipboard, `-o` for file, stdout by default). Alias: `t`.
 
 ## 0.0.7 - 2026-02-05
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ ostt -c              # Record and copy to clipboard (shorthand)
 ostt record -c       # Record and copy to clipboard (explicit)
 ostt -o file         # Record and write to file (shorthand)
 ostt record -o file  # Record and write to file (explicit)
+ostt transcribe file # Transcribe a pre-recorded audio file
+ostt transcribe f -c # Transcribe and copy to clipboard
+ostt transcribe f -o # Transcribe and write to file
 ostt retry [N]       # Re-transcribe recording #N (1=most recent)
 ostt retry -c        # Re-transcribe and copy to clipboard
 ostt replay [N]      # Play back recording #N
@@ -163,7 +166,7 @@ ostt -h              # Quick help
 ostt --help          # Detailed help with examples
 ```
 
-**Command Aliases:** Most commands have short aliases for faster typing: `r` (record), `a` (auth), `h` (history), `k` (keywords), `c` (config), `rp` (replay).
+**Command Aliases:** Most commands have short aliases for faster typing: `r` (record), `t` (transcribe), `a` (auth), `h` (history), `k` (keywords), `c` (config), `rp` (replay).
 
 ```bash
 ostt r -c            # Same as: ostt record -c

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ ostt -o file         # Record and write to file (shorthand)
 ostt record -o file  # Record and write to file (explicit)
 ostt transcribe file # Transcribe a pre-recorded audio file
 ostt transcribe f -c # Transcribe and copy to clipboard
-ostt transcribe f -o # Transcribe and write to file
+ostt transcribe f -o out.txt # Transcribe and write to file
 ostt retry [N]       # Re-transcribe recording #N (1=most recent)
 ostt retry -c        # Re-transcribe and copy to clipboard
 ostt replay [N]      # Play back recording #N
@@ -171,6 +171,15 @@ ostt --help          # Detailed help with examples
 ```bash
 ostt r -c            # Same as: ostt record -c
 ostt a               # Same as: ostt auth
+```
+
+**Transcribe:** The `transcribe` command enables use of ostt's transcription pipeline for pre-recorded audio files, without interactive recording. This is useful for non-interactive workflows such as CI pipelines, GitHub Actions, or agentic scripts where you have an existing audio file and want to leverage ostt's multi-provider transcription infrastructure.
+
+```bash
+ostt transcribe recording.ogg              # Transcribe to stdout
+ostt transcribe voice-memo.mp3 -c          # Transcribe and copy to clipboard
+ostt transcribe meeting.wav -o transcript.txt  # Transcribe and write to file
+ostt transcribe audio.ogg | grep keyword   # Pipe to other commands
 ```
 
 **Record Options:** The `-c` and `-o` flags can be used without explicitly saying `record` since it's the default command:

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use clap_complete::{generate, Shell};
 use dirs;
 use std::env;
 use std::io;
+use std::path::PathBuf;
 use std::process;
 
 /// Suppress ALSA library warnings that are not relevant to the user.
@@ -178,6 +179,31 @@ enum Commands {
     /// Useful for troubleshooting issues.
     Logs,
 
+    /// Transcribe a pre-recorded audio file
+    ///
+    /// Transcribe an existing audio file using the configured provider/model.
+    /// Supports the same output options as record and retry.
+    ///
+    /// Examples:
+    ///   ostt transcribe recording.ogg
+    ///   ostt transcribe voice-memo.mp3 -c
+    ///   ostt transcribe meeting.wav -o transcript.txt
+    ///   ostt transcribe audio.ogg | grep keyword
+    #[command(visible_alias = "t")]
+    Transcribe {
+        /// Path to the audio file to transcribe
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Copy transcription to clipboard instead of stdout
+        #[arg(short, long)]
+        clipboard: bool,
+
+        /// Write transcription to file instead of stdout
+        #[arg(short, long, value_name = "OUTPUT")]
+        output: Option<String>,
+    },
+
     /// Generate shell completion script
     ///
     /// Generate completion script for your shell. Save the output to your
@@ -263,6 +289,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
         }
         Some(Commands::Replay { index }) => {
             commands::handle_replay(index).await?;
+        }
+        Some(Commands::Transcribe {
+            file,
+            clipboard,
+            output,
+        }) => {
+            commands::handle_transcribe(file, clipboard, output).await?;
         }
         Some(Commands::Auth) => {
             if let Err(e) = commands::handle_auth().await {

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,7 +200,7 @@ enum Commands {
         clipboard: bool,
 
         /// Write transcription to file instead of stdout
-        #[arg(short, long, value_name = "OUTPUT")]
+        #[arg(short, long, value_name = "FILE")]
         output: Option<String>,
     },
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -75,7 +75,7 @@ async fn check_and_run_setup() -> Result<(), anyhow::Error> {
 #[command(name = "ostt")]
 #[command(version)]
 #[command(about = "\n\n ┏┓┏╋╋ \n ┗┛┛┗┗")]
-#[command(long_about = "\n\n ┏┓┏╋╋ \n ┗┛┛┗┗\n\nA terminal-based speech-to-text recorder with real-time waveform visualization\nand automatic transcription support.\n\nDEFAULT COMMAND:\n    If no command is specified, 'record' is used by default.\n    Record options (-c, -o) can be used without explicitly saying 'record'.\n\nEXAMPLES:\n    # Record and pipe to other command (default stdout)\n    $ ostt | grep word\n    $ ostt record | grep word\n    \n    # Record and copy to clipboard\n    $ ostt -c\n    $ ostt record -c\n    \n    # Record and write to file\n    $ ostt -o output.txt\n    $ ostt record -o output.txt\n    \n    # Retry most recent recording and pipe output\n    $ ostt retry | wc -w\n    \n    # Retry recording #2 and copy to clipboard\n    $ ostt retry 2 -c\n    \n    # Set up authentication and select a model\n    $ ostt auth\n    \n    # View your transcription history\n    $ ostt history\n    \n    # Edit configuration file\n    $ ostt config")]
+#[command(long_about = "\n\n ┏┓┏╋╋ \n ┗┛┛┗┗\n\nA terminal-based speech-to-text recorder with real-time waveform visualization\nand automatic transcription support.\n\nDEFAULT COMMAND:\n    If no command is specified, 'record' is used by default.\n    Record options (-c, -o) can be used without explicitly saying 'record'.\n\nEXAMPLES:\n    # Record and pipe to other command (default stdout)\n    $ ostt | grep word\n    $ ostt record | grep word\n    \n    # Record and copy to clipboard\n    $ ostt -c\n    $ ostt record -c\n    \n    # Record and write to file\n    $ ostt -o output.txt\n    $ ostt record -o output.txt\n    \n    # Retry most recent recording and pipe output\n    $ ostt retry | wc -w\n    \n    # Retry recording #2 and copy to clipboard\n    $ ostt retry 2 -c\n    \n    # Transcribe a pre-recorded audio file\n    $ ostt transcribe recording.ogg\n    \n    # Transcribe and copy to clipboard\n    $ ostt transcribe voice-memo.mp3 -c\n    \n    # Set up authentication and select a model\n    $ ostt auth\n    \n    # View your transcription history\n    $ ostt history\n    \n    # Edit configuration file\n    $ ostt config")]
 #[command(
     after_help = "CONFIGURATION:\n    Config file:        ~/.config/ostt/ostt.toml\n    Logs:               ~/.local/state/ostt/ostt.log.*\n\nFor more information, visit: https://github.com/kristoferlund/ostt"
 )]
@@ -117,6 +117,31 @@ enum Commands {
         /// Recording index (1 = most recent, 2 = second most recent, etc.)
         #[arg(value_name = "N")]
         index: Option<usize>,
+
+        /// Copy transcription to clipboard instead of stdout
+        #[arg(short, long)]
+        clipboard: bool,
+
+        /// Write transcription to file instead of stdout
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<String>,
+    },
+
+    /// Transcribe a pre-recorded audio file
+    ///
+    /// Transcribe an existing audio file using the configured provider/model.
+    /// Supports the same output options as record and retry.
+    ///
+    /// Examples:
+    ///   ostt transcribe recording.ogg
+    ///   ostt transcribe voice-memo.mp3 -c
+    ///   ostt transcribe meeting.wav -o transcript.txt
+    ///   ostt transcribe audio.ogg | grep keyword
+    #[command(visible_alias = "t")]
+    Transcribe {
+        /// Path to the audio file to transcribe
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
 
         /// Copy transcription to clipboard instead of stdout
         #[arg(short, long)]
@@ -178,31 +203,6 @@ enum Commands {
     /// Display the last 50 lines of the most recent log file.
     /// Useful for troubleshooting issues.
     Logs,
-
-    /// Transcribe a pre-recorded audio file
-    ///
-    /// Transcribe an existing audio file using the configured provider/model.
-    /// Supports the same output options as record and retry.
-    ///
-    /// Examples:
-    ///   ostt transcribe recording.ogg
-    ///   ostt transcribe voice-memo.mp3 -c
-    ///   ostt transcribe meeting.wav -o transcript.txt
-    ///   ostt transcribe audio.ogg | grep keyword
-    #[command(visible_alias = "t")]
-    Transcribe {
-        /// Path to the audio file to transcribe
-        #[arg(value_name = "FILE")]
-        file: PathBuf,
-
-        /// Copy transcription to clipboard instead of stdout
-        #[arg(short, long)]
-        clipboard: bool,
-
-        /// Write transcription to file instead of stdout
-        #[arg(short, long, value_name = "FILE")]
-        output: Option<String>,
-    },
 
     /// Generate shell completion script
     ///
@@ -287,15 +287,15 @@ pub async fn run() -> Result<(), anyhow::Error> {
         }) => {
             commands::handle_retry(index, clipboard, output).await?;
         }
-        Some(Commands::Replay { index }) => {
-            commands::handle_replay(index).await?;
-        }
         Some(Commands::Transcribe {
             file,
             clipboard,
             output,
         }) => {
             commands::handle_transcribe(file, clipboard, output).await?;
+        }
+        Some(Commands::Replay { index }) => {
+            commands::handle_replay(index).await?;
         }
         Some(Commands::Auth) => {
             if let Err(e) = commands::handle_auth().await {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod list_devices;
 pub mod logs;
 pub mod retry;
 pub mod replay;
+pub mod transcribe;
 
 pub use auth::handle_auth;
 pub use record::handle_record;
@@ -33,3 +34,4 @@ pub use list_devices::handle_list_devices;
 pub use logs::handle_logs;
 pub use retry::handle_retry;
 pub use replay::handle_replay;
+pub use transcribe::handle_transcribe;

--- a/src/commands/transcribe.rs
+++ b/src/commands/transcribe.rs
@@ -1,0 +1,124 @@
+//! Transcribe a pre-recorded audio file without recording.
+//!
+//! Accepts an audio file path and transcribes it using the configured provider/model,
+//! reusing the same transcription pipeline as the `record` command.
+
+use crate::clipboard::copy_to_clipboard;
+use crate::config;
+use crate::history::HistoryManager;
+use crate::keywords::KeywordsManager;
+use crate::transcription;
+use dirs;
+use std::path::PathBuf;
+
+/// Handles transcription of a pre-recorded audio file.
+///
+/// Transcribes the given audio file using the currently configured provider and model.
+/// Supports the same output options as `record` and `retry`.
+///
+/// # Arguments
+/// * `file` - Path to the audio file to transcribe
+/// * `clipboard` - If true, copy to clipboard instead of stdout
+/// * `output_file` - Optional file path to write output to instead of stdout
+pub async fn handle_transcribe(
+    file: PathBuf,
+    clipboard: bool,
+    output_file: Option<String>,
+) -> Result<(), anyhow::Error> {
+    tracing::info!("=== ostt Transcribe Command ===");
+
+    // Validate the input file exists
+    if !file.exists() {
+        return Err(anyhow::anyhow!(
+            "Audio file not found: {}",
+            file.display()
+        ));
+    }
+
+    tracing::info!("Transcribing file: {}", file.display());
+
+    // Load configuration
+    let config_data = match config::OsttConfig::load() {
+        Ok(config) => config,
+        Err(err) => {
+            tracing::error!("Failed to load configuration: {err}");
+            return Err(anyhow::anyhow!("Configuration error: {err}"));
+        }
+    };
+
+    // Get the selected model from config
+    let selected_model_id = config::get_selected_model().ok().flatten();
+
+    let model_id = selected_model_id.ok_or_else(|| {
+        anyhow::anyhow!("No model selected. Please run 'ostt auth' to select a transcription model")
+    })?;
+
+    let model = transcription::TranscriptionModel::from_id(&model_id)
+        .ok_or_else(|| anyhow::anyhow!("Unknown model: {model_id}"))?;
+    let provider = model.provider();
+
+    let api_key = config::get_api_key(provider.id())?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No API key for {}. Please run 'ostt auth'",
+                provider.name()
+            )
+        })?;
+
+    // Load keywords
+    let config_dir = dirs::config_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine config directory"))?;
+    let keywords_manager = KeywordsManager::new(&config_dir)?;
+    let keywords = keywords_manager.load_keywords()?;
+
+    // Prepare transcription config
+    let transcription_config = transcription::TranscriptionConfig::new(
+        model,
+        api_key,
+        keywords,
+        config_data.providers.clone(),
+    );
+
+    // Transcribe
+    tracing::debug!("Starting transcription...");
+    let text = transcription::transcribe(&transcription_config, &file)
+        .await
+        .map_err(|e| {
+            tracing::error!("Transcription failed: {e}");
+            anyhow::anyhow!("Transcription failed: {e}")
+        })?;
+
+    let trimmed_text = text.trim().to_string();
+    tracing::debug!("Transcription completed: {}", trimmed_text);
+
+    // Save to history
+    let data_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
+        .join(".local")
+        .join("share")
+        .join("ostt");
+    let mut history_manager = HistoryManager::new(&data_dir)?;
+    let history_note = format!("[Transcribed from {}]", file.display());
+    if let Err(e) = history_manager.save_transcription(&format!("{history_note} {trimmed_text}")) {
+        tracing::warn!("Failed to save transcription to history: {}", e);
+    }
+
+    // Determine output destination: file > clipboard > stdout (default)
+    if let Some(file_path) = output_file {
+        std::fs::write(&file_path, &trimmed_text)
+            .map_err(|e| anyhow::anyhow!("Failed to write to file '{file_path}': {e}"))?;
+        tracing::debug!("Transcribed text written to file: {file_path}");
+    } else if clipboard {
+        if let Err(e) = copy_to_clipboard(&trimmed_text) {
+            tracing::warn!("Failed to copy to clipboard: {e}");
+        } else {
+            tracing::debug!("Transcription copied to clipboard");
+        }
+    } else {
+        // Default: stdout
+        println!("{trimmed_text}");
+        tracing::debug!("Transcribed text printed to stdout");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a new `ostt transcribe` command that accepts a pre-recorded audio file and transcribes it using the configured provider/model — reusing the existing transcription pipeline.

## Usage

```bash
# Basic usage (output to stdout)
ostt transcribe recording.ogg

# Copy to clipboard
ostt transcribe voice-memo.mp3 -c

# Write to file
ostt transcribe meeting.wav -o transcript.txt

# Pipe to other commands
ostt transcribe audio.ogg | grep keyword
```

## Implementation

- New `src/commands/transcribe.rs` module (~120 lines)
- Registered as `Transcribe` subcommand with alias `t`
- Accepts same output flags as `record` and `retry` (`-c`, `-o`)
- Respects configured provider, model, language, and keywords
- Saves transcription results to history (tagged with source file)
- Validates file existence before attempting transcription

The implementation closely follows `retry.rs` — the core change is accepting a user-specified file path instead of reading from recording history.

## Testing

Tested end-to-end with Deepgram nova-2 against real .ogg voice messages:

```
$ ostt transcribe voice-message.ogg
Can you understand if I record a message like this?

$ ostt transcribe another-message.ogg -o /tmp/test.txt
$ cat /tmp/test.txt
So if, later today or in the close future, I would ask for your help...
```

## Motivation

Unlocks several use cases:
- **Automation/scripting** — integrate ostt into audio processing pipelines
- **AI assistant integration** — tools like OpenClaw receive voice messages as files
- **Batch processing** — transcribe multiple files without interactive recording
- **Re-processing** — transcribe files from other tools/devices

Closes #36