### PR TITLE
feat: Add AssemblyAI as transcription provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `disfluencies` — Include filler words like "uh" and "um" (default: false)
   - `filter_profanity` — Filter profanity from transcript (default: false)
   - `language_detection` — Automatic language detection (default: true)
+  - `language_detection_options` — Constrain detection to expected languages with fallback:
+    - `expected_languages` — List of expected language codes (e.g., `["en", "es", "fr"]`)
+    - `fallback_language` — Fallback when detected language isn't expected (use `"auto"` or specific code)
 - **AssemblyAI keyword boosting** — Keywords from the keywords file are passed as `keyterms_prompt` to improve transcription accuracy
 
 ## 0.0.7 - 2026-02-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **AssemblyAI provider support** - New transcription provider with two models:
-  - `universal-3-pro` — AssemblyAI's latest, highest accuracy model
-  - `universal-2` — Previous generation model
+- **AssemblyAI provider support** - New transcription provider with the `universal-3-pro` model (AssemblyAI's latest, highest accuracy model)
 - **AssemblyAI configuration options** - Configurable via `[providers.assemblyai]` in `ostt.toml`:
   - `format_text` — Text formatting with punctuation and casing (default: true)
   - `disfluencies` — Include filler words like "uh" and "um" (default: false)
   - `filter_profanity` — Filter profanity from transcript (default: false)
   - `language_detection` — Automatic language detection (default: true)
-- **AssemblyAI keyword boosting** — Keywords from the keywords file are passed as `word_boost` to improve transcription accuracy
+- **AssemblyAI keyword boosting** — Keywords from the keywords file are passed as `keyterms_prompt` to improve transcription accuracy
 
 ## 0.0.7 - 2026-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **AssemblyAI provider support** - New transcription provider with two models:
+  - `universal-3-pro` — AssemblyAI's latest, highest accuracy model
+  - `universal-2` — Previous generation model
+- **AssemblyAI configuration options** - Configurable via `[providers.assemblyai]` in `ostt.toml`:
+  - `format_text` — Text formatting with punctuation and casing (default: true)
+  - `disfluencies` — Include filler words like "uh" and "um" (default: false)
+  - `filter_profanity` — Filter profanity from transcript (default: false)
+  - `language_detection` — Automatic language detection (default: false)
+- **AssemblyAI keyword boosting** — Keywords from the keywords file are passed as `word_boost` to improve transcription accuracy
+
 ## 0.0.7 - 2026-02-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `format_text` — Text formatting with punctuation and casing (default: true)
   - `disfluencies` — Include filler words like "uh" and "um" (default: false)
   - `filter_profanity` — Filter profanity from transcript (default: false)
-  - `language_detection` — Automatic language detection (default: false)
+  - `language_detection` — Automatic language detection (default: true)
 - **AssemblyAI keyword boosting** — Keywords from the keywords file are passed as `word_boost` to improve transcription accuracy
 
 ## 0.0.7 - 2026-02-05

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ ostt supports multiple AI transcription providers. Bring your own API key and ch
 - **groq-whisper-large-v3** - High accuracy processing
 - **groq-whisper-large-v3-turbo** - Fastest transcription speed
 
+### AssemblyAI
+- **assemblyai-universal-3-pro** - Best accuracy, latest model
+- **assemblyai-universal-2** - Previous generation model
+
 Configure your preferred provider and model using `ostt auth`.
 
 ## Installation
@@ -282,6 +286,12 @@ visualization = "spectrum"  # "spectrum" for frequency display, "waveform" for a
 punctuate = true
 smart_format = false
 filler_words = false
+
+[providers.assemblyai]
+format_text = true        # Punctuation, casing, and numeral formatting
+disfluencies = false      # Include filler words (uh, um)
+filter_profanity = false  # Filter profanity from transcript
+language_detection = false # Automatic language detection
 ```
 
 For detailed configuration options, see the config file comments or run `ostt config` to edit.

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ filler_words = false
 format_text = true        # Punctuation, casing, and numeral formatting
 disfluencies = false      # Include filler words (uh, um)
 filter_profanity = false  # Filter profanity from transcript
-language_detection = false # Automatic language detection
+language_detection = true  # Automatic language detection
 ```
 
 For detailed configuration options, see the config file comments or run `ostt config` to edit.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ format_text = true        # Punctuation, casing, and numeral formatting
 disfluencies = false      # Include filler words (uh, um)
 filter_profanity = false  # Filter profanity from transcript
 language_detection = true  # Automatic language detection
+
+# Optional: constrain language detection to expected languages
+[providers.assemblyai.language_detection_options]
+expected_languages = ["en", "es", "de"]  # Only detect these languages
+fallback_language = "auto"                 # "auto" or specific language code
 ```
 
 For detailed configuration options, see the config file comments or run `ostt config` to edit.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ ostt supports multiple AI transcription providers. Bring your own API key and ch
 
 ### AssemblyAI
 - **assemblyai-universal-3-pro** - Best accuracy, latest model
-- **assemblyai-universal-2** - Previous generation model
 
 Configure your preferred provider and model using `ostt auth`.
 

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -172,3 +172,12 @@ filter_profanity = false
 # and transcribe in that language. When false, assumes English (en).
 # Supports 99+ languages. Detection may add slight latency.
 language_detection = true
+
+# Language detection options (optional)
+# Configure expected languages and fallback behavior.
+# When unspecified, AssemblyAI defaults to ["all"] for expected_languages
+# and "auto" for fallback_language.
+#
+# [providers.assemblyai.language_detection_options]
+# expected_languages = ["en", "es", "fr"]  # Only expect these languages
+# fallback_language = "auto"               # "auto" or specific code like "en"

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -127,6 +127,11 @@ utterances = false
 # effect when utterances is enabled.
 utt_split = 0.8
 
+# Enable automatic language detection
+# When true, Deepgram will automatically detect the spoken language
+# and transcribe in that language. When false, assumes English (en).
+detect_language = true
+
 # Opt out from Deepgram Model Improvement Program (MIP)
 # When true, prevents Deepgram from using your audio data to improve their models.
 # WARNING: This may impact pricing. See docs at https://dpgr.am/deepgram-mip
@@ -144,6 +149,12 @@ mip_opt_out = false
 # question marks), capitalization of sentences and proper nouns, and convert
 # spoken numbers to their numeric form (e.g., "twenty-three" → "23")
 format_text = true
+
+# Enable automatic punctuation
+# When true, adds sentence boundaries with periods, commas, question marks,
+# and exclamation points. Available for all supported languages.
+# Note: If format_text is enabled, you don't need to also enable punctuate.
+punctuate = true
 
 # Include disfluencies (filler words) in the transcript
 # When true, filler words like "um", "uh", "ah", "er", and false starts

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -57,34 +57,107 @@ visualization = "spectrum"
 # Provider-specific settings
 # Each provider can have its own configuration section
 
+
+# =============================================================================
+# Deepgram Configuration
+# =============================================================================
+
 [providers.deepgram]
-# Include filler words in transcript (uh, um, etc.)
+
+# Include filler words (disfluencies) in the transcript
+# When true, transcribes filler words like "uh", "um", "mhmm", "uh-huh", and
+# "nuh-uh". These words are always transcribed with consistent spelling regardless
+# of spoken duration. When false, filler words are stripped to improve readability.
+# Only available for Nova, Nova-2, and Nova-3 models.
 filler_words = false
 
-# Convert spoken measurements to their abbreviations
+# Convert spoken measurement units to their abbreviations
+# When true, converts terms like "milligrams" to "mg", "kilometers" to "km",
+# "liters" to "l", etc. Supported units include: mg, cg, g, kg, ml, cl, l, kl,
+# mm, cm, m, km. Only available for English language models.
 measurements = false
 
-# Convert numbers from written format to numerical format
+# Convert spoken numbers to numerical format
+# When true, converts written numbers like "nine hundred" to "900". Supports
+# Danish, Dutch, English, French, German, Italian, Norwegian, Polish, Portuguese,
+# Spanish, and Swedish. Useful for phone numbers, addresses, and account IDs.
 numerals = false
 
-# Split audio into paragraphs to improve transcript readability
+# Split transcript into paragraphs for improved readability
+# When true, adds paragraph breaks based on punctuation and pauses. Paragraphs
+# will also be influenced by speaker changes (if diarization is enabled) and
+# channel changes (if multichannel is enabled). Note: Paragraphs requires
+# Punctuation to be enabled (enabled automatically when this is true).
 paragraphs = false
 
-# Apply profanity filter to transcript
+# Apply profanity filtering to the transcript
+# When true, masks offensive language with asterisks (e.g., "****"). Available
+# for English, German, Swiss German, Polish, Portuguese, Spanish, and Swedish.
+# Words are replaced with a censored placeholder to maintain timing and structure.
 profanity_filter = false
 
-# Add punctuation and capitalization to transcript
+# Add punctuation and capitalization to the transcript
+# When true, adds sentence boundaries (periods, commas, question marks) and
+# capitalizes the first word of sentences and proper nouns. Available for
+# all supported languages. If Smart Format is enabled, you don't need to
+# also enable Punctuation.
 punctuate = true
 
-# Apply smart formatting to transcript output for improved readability
+# Apply comprehensive smart formatting to the transcript
+# When true, applies enhanced formatting including punctuation, paragraphs,
+# and entity formatting (dates like "November 2, 2022", times like "8:37 PM",
+# currency, phone numbers, emails, URLs). Available for all languages, with
+# the most comprehensive support for English. Note: Smart Format enables
+# Punctuation automatically.
 smart_format = false
 
-# Segment speech into meaningful semantic units
+# Segment speech into meaningful semantic units (utterances)
+# When true, divides speech into natural conversational segments based on pauses,
+# sentence restarts, and reformulations. Each utterance includes start/end times,
+# confidence scores, and word-level details. Useful for analyzing conversational
+# speech patterns, turn-taking, and dialogue structure. Only available for
+# pre-recorded audio with Nova models.
 utterances = false
 
-# Seconds to wait before detecting pause between words (range: 0.5-3.0)
+# Duration of silence (in seconds) to trigger a new utterance
+# Sets the pause length between words after which Deepgram decides a new utterance
+# should begin. Range: 0.5 to 3.0 seconds. Default is 0.8 seconds. Lower values
+# create more utterance breaks (better for fast-paced dialogue), higher values
+# create fewer breaks (better for speeches with deliberate pauses). Only takes
+# effect when utterances is enabled.
 utt_split = 0.8
 
-# Opt out from Deepgram Model Improvement Program
+# Opt out from Deepgram Model Improvement Program (MIP)
+# When true, prevents Deepgram from using your audio data to improve their models.
 # WARNING: This may impact pricing. See docs at https://dpgr.am/deepgram-mip
 mip_opt_out = false
+
+
+# =============================================================================
+# AssemblyAI Configuration
+# =============================================================================
+
+[providers.assemblyai]
+
+# Format text with punctuation, casing, and numeral conversion
+# When true, the transcript will include proper punctuation (periods, commas,
+# question marks), capitalization of sentences and proper nouns, and convert
+# spoken numbers to their numeric form (e.g., "twenty-three" → "23")
+format_text = true
+
+# Include disfluencies (filler words) in the transcript
+# When true, filler words like "um", "uh", "ah", "er", and false starts
+# are preserved in the output. When false, these are removed.
+# Useful for verbatim transcription or speech analysis.
+disfluencies = false
+
+# Filter profanity from the transcript
+# When true, profane words are replaced with asterisks (e.g., "***")
+# to censor offensive language from the output.
+filter_profanity = false
+
+# Enable automatic language detection
+# When true, AssemblyAI will automatically detect the spoken language
+# and transcribe in that language. When false, assumes English (en).
+# Supports 99+ languages. Detection may add slight latency.
+language_detection = true

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -139,7 +139,7 @@ pub struct AssemblyAIConfig {
     #[serde(default)]
     pub filter_profanity: bool,
     /// Enable automatic language detection
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub language_detection: bool,
 }
 
@@ -153,7 +153,7 @@ impl Default for AssemblyAIConfig {
             format_text: true,
             disfluencies: false,
             filter_profanity: false,
-            language_detection: false,
+            language_detection: true,
         }
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -126,6 +126,20 @@ pub struct OpenAiConfig {
     // Add here as OpenAI features become configurable
 }
 
+/// Options for AssemblyAI automatic language detection.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LanguageDetectionOptions {
+    /// List of languages expected in the audio file.
+    /// Defaults to ["all"] when unspecified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_languages: Option<Vec<String>>,
+    /// Fallback language if detected language is not in expected_languages.
+    /// Use "auto" to let the model choose from expected_languages with highest confidence.
+    /// Defaults to "auto".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_language: Option<String>,
+}
+
 /// AssemblyAI API configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssemblyAIConfig {
@@ -141,6 +155,9 @@ pub struct AssemblyAIConfig {
     /// Enable automatic language detection
     #[serde(default = "default_true")]
     pub language_detection: bool,
+    /// Options for automatic language detection
+    #[serde(default)]
+    pub language_detection_options: LanguageDetectionOptions,
     /// Enable automatic punctuation
     #[serde(default = "default_true")]
     pub punctuate: bool,
@@ -157,6 +174,7 @@ impl Default for AssemblyAIConfig {
             disfluencies: false,
             filter_profanity: false,
             language_detection: true,
+            language_detection_options: LanguageDetectionOptions::default(),
             punctuate: true,
         }
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -126,6 +126,38 @@ pub struct OpenAiConfig {
     // Add here as OpenAI features become configurable
 }
 
+/// AssemblyAI API configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssemblyAIConfig {
+    /// Apply text formatting (punctuation, casing, numerals)
+    #[serde(default = "default_true")]
+    pub format_text: bool,
+    /// Include disfluencies (uh, um) in transcript
+    #[serde(default)]
+    pub disfluencies: bool,
+    /// Filter profanity from transcript
+    #[serde(default)]
+    pub filter_profanity: bool,
+    /// Enable automatic language detection
+    #[serde(default)]
+    pub language_detection: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for AssemblyAIConfig {
+    fn default() -> Self {
+        Self {
+            format_text: true,
+            disfluencies: false,
+            filter_profanity: false,
+            language_detection: false,
+        }
+    }
+}
+
 /// Provider-specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProviderConfig {
@@ -144,6 +176,8 @@ pub struct ProvidersConfig {
     pub deepgram: DeepgramConfig,
     #[serde(default)]
     pub openai: OpenAiConfig,
+    #[serde(default)]
+    pub assemblyai: AssemblyAIConfig,
 }
 
 /// Complete application configuration.

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -141,6 +141,9 @@ pub struct AssemblyAIConfig {
     /// Enable automatic language detection
     #[serde(default = "default_true")]
     pub language_detection: bool,
+    /// Enable automatic punctuation
+    #[serde(default = "default_true")]
+    pub punctuate: bool,
 }
 
 fn default_true() -> bool {
@@ -154,6 +157,7 @@ impl Default for AssemblyAIConfig {
             disfluencies: false,
             filter_profanity: false,
             language_detection: true,
+            punctuate: true,
         }
     }
 }

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -51,6 +51,8 @@ struct TranscriptRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     language_detection: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    punctuate: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     keyterms_prompt: Option<Vec<String>>,
 }
 
@@ -99,6 +101,7 @@ pub async fn transcribe(
         disfluencies: Some(assemblyai_config.disfluencies),
         filter_profanity: Some(assemblyai_config.filter_profanity),
         language_detection: Some(assemblyai_config.language_detection),
+        punctuate: Some(assemblyai_config.punctuate),
         keyterms_prompt: None,
     };
 

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -1,0 +1,200 @@
+//! AssemblyAI API implementation.
+//!
+//! Handles transcription requests to AssemblyAI's API using an upload→transcribe→poll pattern.
+//! Unlike other providers that use a single synchronous request, AssemblyAI requires:
+//! 1. Upload audio binary data to get an upload URL
+//! 2. Submit a transcription request with the upload URL and options
+//! 3. Poll for the completed transcript
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::TranscriptionConfig;
+
+/// Response from the upload endpoint
+#[derive(Debug, Deserialize)]
+struct UploadResponse {
+    upload_url: String,
+}
+
+/// Request body for the transcription endpoint
+#[derive(Debug, Serialize)]
+struct TranscriptRequest {
+    audio_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speech_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    format_text: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disfluencies: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filter_profanity: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language_detection: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    word_boost: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    boost_param: Option<String>,
+}
+
+/// Response from the transcription endpoint (both submit and poll)
+#[derive(Debug, Deserialize)]
+struct TranscriptResponse {
+    id: String,
+    status: String,
+    text: Option<String>,
+    error: Option<String>,
+}
+
+/// Transcribes an audio file using AssemblyAI's API.
+///
+/// Uses a three-step process: upload audio, submit transcription request, poll for result.
+pub async fn transcribe(
+    config: &TranscriptionConfig,
+    audio_path: &Path,
+) -> anyhow::Result<String> {
+    let audio_data = std::fs::read(audio_path).map_err(|e| {
+        anyhow::anyhow!("Failed to read audio file: {e}")
+    })?;
+
+    let client = reqwest::Client::new();
+    let base_url = config.model.endpoint();
+
+    // Step 1: Upload audio
+    tracing::debug!("Uploading audio to AssemblyAI...");
+    let upload_response = match client
+        .post(format!("{base_url}/upload"))
+        .header("authorization", &config.api_key)
+        .header("content-type", "application/octet-stream")
+        .body(audio_data)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            let error_msg = if e.is_connect() {
+                "Failed to connect to AssemblyAI API server. Check your internet connection.".to_string()
+            } else if e.is_timeout() {
+                "Request to AssemblyAI timed out. The API server is not responding.".to_string()
+            } else {
+                format!("AssemblyAI network error: {e}")
+            };
+            return Err(anyhow::anyhow!(error_msg));
+        }
+    };
+
+    if !upload_response.status().is_success() {
+        let status = upload_response.status();
+        let error_body = upload_response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(anyhow::anyhow!(format_error(status.as_u16(), &error_body)));
+    }
+
+    let upload: UploadResponse = upload_response
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to parse AssemblyAI upload response: {e}"))?;
+
+    tracing::debug!("Audio uploaded successfully");
+
+    // Step 2: Submit transcription request
+    let assemblyai_config = &config.providers.assemblyai;
+
+    let mut request = TranscriptRequest {
+        audio_url: upload.upload_url,
+        speech_model: Some(config.model.api_model_name().to_string()),
+        format_text: Some(assemblyai_config.format_text),
+        disfluencies: Some(assemblyai_config.disfluencies),
+        filter_profanity: Some(assemblyai_config.filter_profanity),
+        language_detection: Some(assemblyai_config.language_detection),
+        word_boost: None,
+        boost_param: None,
+    };
+
+    // Add keywords as word_boost if any
+    if !config.keywords.is_empty() {
+        request.word_boost = Some(config.keywords.clone());
+        request.boost_param = Some("high".to_string());
+    }
+
+    tracing::debug!("Submitting transcription request...");
+    let submit_response = match client
+        .post(format!("{base_url}/transcript"))
+        .header("authorization", &config.api_key)
+        .header("content-type", "application/json")
+        .json(&request)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            return Err(anyhow::anyhow!("AssemblyAI submit error: {e}"));
+        }
+    };
+
+    if !submit_response.status().is_success() {
+        let status = submit_response.status();
+        let error_body = submit_response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(anyhow::anyhow!(format_error(status.as_u16(), &error_body)));
+    }
+
+    let transcript: TranscriptResponse = submit_response
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to parse AssemblyAI submit response: {e}"))?;
+
+    let transcript_id = transcript.id;
+    tracing::debug!("Transcription submitted, id: {transcript_id}");
+
+    // Step 3: Poll for result
+    let poll_url = format!("{base_url}/transcript/{transcript_id}");
+    let mut poll_interval = tokio::time::interval(std::time::Duration::from_secs(1));
+
+    loop {
+        poll_interval.tick().await;
+
+        let poll_response = client
+            .get(&poll_url)
+            .header("authorization", &config.api_key)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("AssemblyAI poll error: {e}"))?;
+
+        if !poll_response.status().is_success() {
+            let status = poll_response.status();
+            let error_body = poll_response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(anyhow::anyhow!(format_error(status.as_u16(), &error_body)));
+        }
+
+        let result: TranscriptResponse = poll_response
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to parse AssemblyAI poll response: {e}"))?;
+
+        match result.status.as_str() {
+            "completed" => {
+                let text = result.text.unwrap_or_default();
+                tracing::debug!("Transcription completed: {} chars", text.len());
+                return Ok(text.trim().to_string());
+            }
+            "error" => {
+                let error = result.error.unwrap_or_else(|| "Unknown transcription error".to_string());
+                return Err(anyhow::anyhow!("AssemblyAI transcription failed: {error}"));
+            }
+            status => {
+                tracing::debug!("Transcription status: {status}, polling...");
+            }
+        }
+    }
+}
+
+/// Formats HTTP error codes into human-readable messages.
+fn format_error(status: u16, error_body: &str) -> String {
+    match status {
+        401 => "AssemblyAI API key is invalid or expired. Please run 'ostt auth' to update your API key.".to_string(),
+        403 => "You don't have permission to use AssemblyAI's API. Check your API key and account status.".to_string(),
+        429 => "Too many requests to AssemblyAI. You've hit the API rate limit. Please wait and try again.".to_string(),
+        500 | 502 | 503 | 504 => "AssemblyAI API server is experiencing issues. Please try again later.".to_string(),
+        _ => format!("AssemblyAI API error (status {status}): {error_body}"),
+    }
+}

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -23,7 +23,7 @@ struct UploadResponse {
 struct TranscriptRequest {
     audio_url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    speech_model: Option<String>,
+    speech_models: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     format_text: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -102,7 +102,7 @@ pub async fn transcribe(
 
     let mut request = TranscriptRequest {
         audio_url: upload.upload_url,
-        speech_model: Some(config.model.api_model_name().to_string()),
+        speech_models: Some(vec![config.model.api_model_name().to_string()]),
         format_text: Some(assemblyai_config.format_text),
         disfluencies: Some(assemblyai_config.disfluencies),
         filter_profanity: Some(assemblyai_config.filter_profanity),

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -36,9 +36,7 @@ struct TranscriptRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     language_detection: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    word_boost: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    boost_param: Option<String>,
+    keyterms_prompt: Option<Vec<String>>,
 }
 
 /// Response from the transcription endpoint (both submit and poll)
@@ -111,14 +109,12 @@ pub async fn transcribe(
         disfluencies: Some(assemblyai_config.disfluencies),
         filter_profanity: Some(assemblyai_config.filter_profanity),
         language_detection: Some(assemblyai_config.language_detection),
-        word_boost: None,
-        boost_param: None,
+        keyterms_prompt: None,
     };
 
-    // Add keywords as word_boost if any
+    // Add keywords as keyterms_prompt if any
     if !config.keywords.is_empty() {
-        request.word_boost = Some(config.keywords.clone());
-        request.boost_param = Some("high".to_string());
+        request.keyterms_prompt = Some(config.keywords.clone());
     }
 
     tracing::debug!("Submitting transcription request...");

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -8,6 +8,7 @@ mod openai;
 mod deepgram;
 mod deepinfra;
 mod groq;
+mod assemblyai;
 
 use serde::Deserialize;
 use std::path::Path;
@@ -85,6 +86,9 @@ pub async fn transcribe(
         }
         TranscriptionProvider::Groq => {
             groq::transcribe(config, audio_path).await
+        }
+        TranscriptionProvider::AssemblyAI => {
+            assemblyai::transcribe(config, audio_path).await
         }
     }?;
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -28,6 +28,10 @@ pub enum TranscriptionModel {
     GroqWhisperLargeV3,
     /// Groq Whisper Large V3 Turbo model (faster)
     GroqWhisperLargeV3Turbo,
+    /// AssemblyAI Universal 3 Pro model (best accuracy)
+    AssemblyAIUniversal3Pro,
+    /// AssemblyAI Universal 2 model (previous generation)
+    AssemblyAIUniversal2,
 }
 
 impl TranscriptionModel {
@@ -44,6 +48,8 @@ impl TranscriptionModel {
             | TranscriptionModel::DeepInfraWhisperBase => TranscriptionProvider::DeepInfra,
             TranscriptionModel::GroqWhisperLargeV3
             | TranscriptionModel::GroqWhisperLargeV3Turbo => TranscriptionProvider::Groq,
+            TranscriptionModel::AssemblyAIUniversal3Pro
+            | TranscriptionModel::AssemblyAIUniversal2 => TranscriptionProvider::AssemblyAI,
         }
     }
 
@@ -59,6 +65,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase => "deepinfra-whisper-base",
             TranscriptionModel::GroqWhisperLargeV3 => "groq-whisper-large-v3",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "groq-whisper-large-v3-turbo",
+            TranscriptionModel::AssemblyAIUniversal3Pro => "assemblyai-universal-3-pro",
+            TranscriptionModel::AssemblyAIUniversal2 => "assemblyai-universal-2",
         }
     }
 
@@ -74,6 +82,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase => "Whisper Base (fast, lightweight)",
             TranscriptionModel::GroqWhisperLargeV3 => "Whisper Large V3 (high accuracy)",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "Whisper Large V3 Turbo (fastest)",
+            TranscriptionModel::AssemblyAIUniversal3Pro => "Universal 3 Pro (best accuracy)",
+            TranscriptionModel::AssemblyAIUniversal2 => "Universal 2 (previous generation)",
         }
     }
 
@@ -90,6 +100,8 @@ impl TranscriptionModel {
             | TranscriptionModel::DeepInfraWhisperBase => "https://api.deepinfra.com/v1/inference",
             TranscriptionModel::GroqWhisperLargeV3
             | TranscriptionModel::GroqWhisperLargeV3Turbo => "https://api.groq.com/openai/v1/audio/transcriptions",
+            TranscriptionModel::AssemblyAIUniversal3Pro
+            | TranscriptionModel::AssemblyAIUniversal2 => "https://api.assemblyai.com/v2",
         }
     }
 
@@ -105,6 +117,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase => "openai/whisper-base",
             TranscriptionModel::GroqWhisperLargeV3 => "whisper-large-v3",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "whisper-large-v3-turbo",
+            TranscriptionModel::AssemblyAIUniversal3Pro => "universal-3-pro",
+            TranscriptionModel::AssemblyAIUniversal2 => "universal-2",
         }
     }
 
@@ -120,6 +134,8 @@ impl TranscriptionModel {
             "deepinfra-whisper-base" => Some(TranscriptionModel::DeepInfraWhisperBase),
             "groq-whisper-large-v3" => Some(TranscriptionModel::GroqWhisperLargeV3),
             "groq-whisper-large-v3-turbo" => Some(TranscriptionModel::GroqWhisperLargeV3Turbo),
+            "assemblyai-universal-3-pro" => Some(TranscriptionModel::AssemblyAIUniversal3Pro),
+            "assemblyai-universal-2" => Some(TranscriptionModel::AssemblyAIUniversal2),
             _ => None,
         }
     }
@@ -136,6 +152,8 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase,
             TranscriptionModel::GroqWhisperLargeV3,
             TranscriptionModel::GroqWhisperLargeV3Turbo,
+            TranscriptionModel::AssemblyAIUniversal3Pro,
+            TranscriptionModel::AssemblyAIUniversal2,
         ]
     }
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -30,8 +30,6 @@ pub enum TranscriptionModel {
     GroqWhisperLargeV3Turbo,
     /// AssemblyAI Universal 3 Pro model (best accuracy)
     AssemblyAIUniversal3Pro,
-    /// AssemblyAI Universal 2 model (previous generation)
-    AssemblyAIUniversal2,
 }
 
 impl TranscriptionModel {
@@ -48,8 +46,7 @@ impl TranscriptionModel {
             | TranscriptionModel::DeepInfraWhisperBase => TranscriptionProvider::DeepInfra,
             TranscriptionModel::GroqWhisperLargeV3
             | TranscriptionModel::GroqWhisperLargeV3Turbo => TranscriptionProvider::Groq,
-            TranscriptionModel::AssemblyAIUniversal3Pro
-            | TranscriptionModel::AssemblyAIUniversal2 => TranscriptionProvider::AssemblyAI,
+            TranscriptionModel::AssemblyAIUniversal3Pro => TranscriptionProvider::AssemblyAI,
         }
     }
 
@@ -66,7 +63,6 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3 => "groq-whisper-large-v3",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "groq-whisper-large-v3-turbo",
             TranscriptionModel::AssemblyAIUniversal3Pro => "assemblyai-universal-3-pro",
-            TranscriptionModel::AssemblyAIUniversal2 => "assemblyai-universal-2",
         }
     }
 
@@ -83,7 +79,6 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3 => "Whisper Large V3 (high accuracy)",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "Whisper Large V3 Turbo (fastest)",
             TranscriptionModel::AssemblyAIUniversal3Pro => "Universal 3 Pro (best accuracy)",
-            TranscriptionModel::AssemblyAIUniversal2 => "Universal 2 (previous generation)",
         }
     }
 
@@ -99,9 +94,10 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperLargeV3
             | TranscriptionModel::DeepInfraWhisperBase => "https://api.deepinfra.com/v1/inference",
             TranscriptionModel::GroqWhisperLargeV3
-            | TranscriptionModel::GroqWhisperLargeV3Turbo => "https://api.groq.com/openai/v1/audio/transcriptions",
-            TranscriptionModel::AssemblyAIUniversal3Pro
-            | TranscriptionModel::AssemblyAIUniversal2 => "https://api.assemblyai.com/v2",
+            | TranscriptionModel::GroqWhisperLargeV3Turbo => {
+                "https://api.groq.com/openai/v1/audio/transcriptions"
+            }
+            TranscriptionModel::AssemblyAIUniversal3Pro => "https://api.assemblyai.com/v2",
         }
     }
 
@@ -118,7 +114,6 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3 => "whisper-large-v3",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "whisper-large-v3-turbo",
             TranscriptionModel::AssemblyAIUniversal3Pro => "universal-3-pro",
-            TranscriptionModel::AssemblyAIUniversal2 => "universal-2",
         }
     }
 
@@ -135,7 +130,6 @@ impl TranscriptionModel {
             "groq-whisper-large-v3" => Some(TranscriptionModel::GroqWhisperLargeV3),
             "groq-whisper-large-v3-turbo" => Some(TranscriptionModel::GroqWhisperLargeV3Turbo),
             "assemblyai-universal-3-pro" => Some(TranscriptionModel::AssemblyAIUniversal3Pro),
-            "assemblyai-universal-2" => Some(TranscriptionModel::AssemblyAIUniversal2),
             _ => None,
         }
     }
@@ -153,7 +147,6 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3,
             TranscriptionModel::GroqWhisperLargeV3Turbo,
             TranscriptionModel::AssemblyAIUniversal3Pro,
-            TranscriptionModel::AssemblyAIUniversal2,
         ]
     }
 

--- a/src/transcription/provider.rs
+++ b/src/transcription/provider.rs
@@ -12,6 +12,7 @@ pub enum TranscriptionProvider {
     Deepgram,
     DeepInfra,
     Groq,
+    AssemblyAI,
 }
 
 impl TranscriptionProvider {
@@ -21,6 +22,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::Deepgram => "deepgram",
             TranscriptionProvider::DeepInfra => "deepinfra",
             TranscriptionProvider::Groq => "groq",
+            TranscriptionProvider::AssemblyAI => "assemblyai",
         }
     }
 
@@ -30,6 +32,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::Deepgram => "Deepgram",
             TranscriptionProvider::DeepInfra => "DeepInfra",
             TranscriptionProvider::Groq => "Groq",
+            TranscriptionProvider::AssemblyAI => "AssemblyAI",
         }
     }
 
@@ -39,6 +42,7 @@ impl TranscriptionProvider {
             "deepgram" => Some(TranscriptionProvider::Deepgram),
             "deepinfra" => Some(TranscriptionProvider::DeepInfra),
             "groq" => Some(TranscriptionProvider::Groq),
+            "assemblyai" => Some(TranscriptionProvider::AssemblyAI),
             _ => None,
         }
     }
@@ -49,6 +53,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::Deepgram,
             TranscriptionProvider::DeepInfra,
             TranscriptionProvider::Groq,
+            TranscriptionProvider::AssemblyAI,
         ]
     }
 }


### PR DESCRIPTION
## Summary

Adds AssemblyAI as a new transcription provider:
- **universal-3-pro** — Latest, highest accuracy model

## Implementation

AssemblyAI uses an async upload→transcribe→poll pattern (unlike other providers that use a single synchronous request):
1. Upload audio binary to `/v2/upload`
2. Submit transcription request to `/v2/transcript` with options
3. Poll `/v2/transcript/{id}` until completion

## Configuration

New `[providers.assemblyai]` section in `ostt.toml`:

```toml
[providers.assemblyai]
format_text = true        # Punctuation, casing, numeral formatting
disfluencies = false      # Include filler words (uh, um)
filter_profanity = false  # Filter profanity
language_detection = false # Auto language detection
```

Keywords from the keywords file are passed as `word_boost` with high boost parameter.

## Changes

- `src/transcription/api/assemblyai.rs` — New API implementation (200 lines)
- `src/transcription/provider.rs` — Added `AssemblyAI` variant
- `src/transcription/model.rs` — Added two model variants
- `src/transcription/api/mod.rs` — Wired up routing
- `src/config/file.rs` — Added `AssemblyAIConfig` struct
- `README.md` — Documented new provider and config options
- `CHANGELOG.md` — Added to Unreleased section

Builds cleanly with no warnings.