### PR TITLE
Add/berget api support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Berget provider** - Added support for Berget transcription service with Swedish-optimized KB Whisper Large model
+
 ## 0.0.7 - 2026-02-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deepgram language detection** - Enable automatic language detection with `detect_language` option (default: true). Previously Deepgram defaulted to English only.
 - **Deepgram language detection restriction** - Restrict detectable languages with `detect_language_codes` option. For example, `detect_language_codes = ["en", "es"]` will only detect English or Spanish.
 - **AssemblyAI provider** - New transcription provider with the `universal-3-pro` model. Configurable via `[providers.assemblyai]` in `ostt.toml`.
-- **Berget provider** - New transcription provider with the Swedish-optimized `kb-whisper-large` model. Data stays within Sweden.
+- **Berget provider** - New transcription provider with 3 models: KB Whisper Large (Swedish optimized), NB Whisper Large (Norwegian optimized), and Whisper Large V3 (general-purpose). All data stays within Sweden.
 
 ## 0.0.7 - 2026-02-05
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ ostt supports multiple AI transcription providers. Bring your own API key and ch
 - **groq-whisper-large-v3** - High accuracy processing
 - **groq-whisper-large-v3-turbo** - Fastest transcription speed
 
+### Berget
+- **berget-whisper-kb-large** - KB Whisper Large (Swedish optimized)
+
 Configure your preferred provider and model using `ostt auth`.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ ostt supports multiple AI transcription providers. Bring your own API key and ch
 - **assemblyai-universal-3-pro** - Best accuracy, latest model
 
 ### Berget
-- **berget-whisper-kb-large** - KB Whisper Large (Swedish optimized)
+
+Berget is a Swedish cloud provider guaranteeing that data never leaves Sweden. All models are hosted within Swedish borders.
+
+- **berget-whisper-kb-large** - KB Whisper Large, developed by the National Library of Sweden. Trained on 50,000+ hours of Swedish speech, reduces WER by 47% compared to OpenAI's whisper-large-v3 on Swedish.
+- **berget-whisper-nb-large** - NB Whisper Large, developed by the National Library of Norway. Trained on 66,000 hours of Norwegian speech, optimized for Norwegian ASR.
+- **berget-whisper-large-v3** - OpenAI Whisper Large V3, general-purpose multilingual model hosted on Berget infrastructure.
 
 Configure your preferred provider and model using `ostt auth`.
 

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -303,6 +303,7 @@ async fn transcribe_recording_with_animation(
         transcription::transcribe(&transcription_config, filename.as_ref()).await
     });
 
+    let mut cancelled = false;
     loop {
         if let Err(e) = tui.render_transcription_animation(&mut animation) {
             tracing::warn!("Failed to render animation: {}", e);
@@ -312,7 +313,38 @@ async fn transcribe_recording_with_animation(
             break;
         }
 
+        // Check for cancel input (Escape, 'q', or Ctrl+C)
+        if crossterm::event::poll(std::time::Duration::from_millis(0))
+            .unwrap_or(false)
+        {
+            if let Ok(crossterm::event::Event::Key(key)) = crossterm::event::read() {
+                match key.code {
+                    crossterm::event::KeyCode::Esc | crossterm::event::KeyCode::Char('q') => {
+                        tracing::info!("Transcription cancelled by user");
+                        transcription_handle.abort();
+                        cancelled = true;
+                        break;
+                    }
+                    crossterm::event::KeyCode::Char('c')
+                        if key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                    {
+                        tracing::info!("Transcription cancelled by user (Ctrl+C)");
+                        transcription_handle.abort();
+                        cancelled = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    if cancelled {
+        return Err(anyhow::anyhow!("Transcription cancelled"));
     }
 
     match transcription_handle.await {

--- a/src/transcription/api/berget.rs
+++ b/src/transcription/api/berget.rs
@@ -1,0 +1,126 @@
+//! Berget API implementation.
+//!
+//! Handles transcription requests to Berget's OpenAI-compatible Whisper API using multipart form data.
+
+use std::path::Path;
+use serde::Deserialize;
+
+use super::TranscriptionConfig;
+
+/// Berget API response wrapper
+#[derive(Debug, Deserialize)]
+struct BergetResponse {
+    text: String,
+}
+
+/// Berget API error response
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct BergetErrorResponse {
+    code: String,
+    error: String,
+    #[serde(default)]
+    details: Option<String>,
+}
+
+/// Transcribes an audio file using Berget's Whisper API.
+///
+/// Uses multipart form data with bearer token authentication.
+/// Berget provides an OpenAI-compatible API endpoint.
+///
+/// Keywords are passed as the `prompt` parameter to guide transcription context.
+pub async fn transcribe(
+    config: &TranscriptionConfig,
+    audio_path: &Path,
+) -> anyhow::Result<String> {
+    let audio_data = std::fs::read(audio_path).map_err(|e| {
+        anyhow::anyhow!("Failed to read audio file: {e}")
+    })?;
+
+    let client = reqwest::Client::new();
+
+    let file_name = audio_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let file_part = reqwest::multipart::Part::bytes(audio_data)
+        .file_name(file_name.clone())
+        .mime_str("audio/mpeg")
+        .map_err(|e| anyhow::anyhow!("Failed to create file part for upload: {e}"))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", file_part)
+        .text("model", config.model.api_model_name().to_string());
+
+    // Debug log: Log the API call details (without the audio data)
+    let mut debug_params = vec![
+        format!("model={}", config.model.api_model_name()),
+    ];
+
+    // Add keywords as prompt for better transcription context
+    if !config.keywords.is_empty() {
+        let prompt = config.keywords.join(", ");
+        form = form.text("prompt", prompt.clone());
+        debug_params.push(format!("prompt={prompt}"));
+        tracing::debug!("Keywords used as prompt for Berget model: {:?}", config.keywords);
+    }
+
+    let endpoint = config.model.endpoint();
+
+    tracing::debug!(
+        "Berget API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",
+        endpoint,
+        debug_params.join("\n    ")
+    );
+
+    let response = match client
+        .post(endpoint)
+        .bearer_auth(&config.api_key)
+        .multipart(form)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            let error_msg = if e.is_connect() {
+                "Failed to connect to Berget API server. Check your internet connection.".to_string()
+            } else if e.is_timeout() {
+                "Request to Berget timed out. The API server is not responding.".to_string()
+            } else if e.to_string().contains("builder") {
+                format!("Failed to build Berget API request: {e}. This may be a configuration error.")
+            } else {
+                format!("Berget network error: {e}")
+            };
+            return Err(anyhow::anyhow!(error_msg));
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status();
+        
+        // Parse the JSON error response - all errors follow the same structure
+        let error_message = response
+            .json::<BergetErrorResponse>()
+            .await
+            .map(|e| e.error)
+            .unwrap_or_else(|_| format!("HTTP {status}"));
+
+        return Err(anyhow::anyhow!("Berget API error: {error_message}"));
+    }
+
+    let berget_response: BergetResponse = response
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to parse Berget response: {e}"))?;
+
+    // Debug log: Log the full response for debugging
+    tracing::debug!(
+        "Berget API Response:\n  Status: Success\n  Transcription length: {} characters\n  Full response: {:#?}",
+        berget_response.text.len(),
+        berget_response
+    );
+
+    Ok(berget_response.text.trim().to_string())
+}

--- a/src/transcription/api/berget.rs
+++ b/src/transcription/api/berget.rs
@@ -18,7 +18,8 @@ struct BergetResponse {
 /// Uses multipart form data with bearer token authentication.
 /// Berget provides an OpenAI-compatible API endpoint.
 ///
-/// Keywords are passed as the `prompt` parameter to guide transcription context.
+/// Keywords are passed as the `hotwords` parameter (Berget's dedicated keyword boosting)
+/// and as the `prompt` parameter (Whisper-compatible context hint).
 pub async fn transcribe(
     config: &TranscriptionConfig,
     audio_path: &Path,
@@ -49,12 +50,14 @@ pub async fn transcribe(
         format!("model={}", config.model.api_model_name()),
     ];
 
-    // Add keywords as prompt for better transcription context
+    // Add keywords as hotwords (Berget-specific) and prompt (Whisper-compatible)
     if !config.keywords.is_empty() {
-        let prompt = config.keywords.join(", ");
-        form = form.text("prompt", prompt.clone());
-        debug_params.push(format!("prompt={prompt}"));
-        tracing::debug!("Keywords used as prompt for Berget model: {:?}", config.keywords);
+        let keywords_csv = config.keywords.join(", ");
+        form = form.text("hotwords", keywords_csv.clone());
+        form = form.text("prompt", keywords_csv.clone());
+        debug_params.push(format!("hotwords={keywords_csv}"));
+        debug_params.push(format!("prompt={keywords_csv}"));
+        tracing::debug!("Keywords used for Berget model: {:?}", config.keywords);
     }
 
     let endpoint = config.model.endpoint();

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -8,6 +8,7 @@ mod openai;
 mod deepgram;
 mod deepinfra;
 mod groq;
+mod berget;
 
 use serde::Deserialize;
 use std::path::Path;
@@ -85,6 +86,9 @@ pub async fn transcribe(
         }
         TranscriptionProvider::Groq => {
             groq::transcribe(config, audio_path).await
+        }
+        TranscriptionProvider::Berget => {
+            berget::transcribe(config, audio_path).await
         }
     }?;
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -28,6 +28,8 @@ pub enum TranscriptionModel {
     GroqWhisperLargeV3,
     /// Groq Whisper Large V3 Turbo model (faster)
     GroqWhisperLargeV3Turbo,
+    /// Berget Whisper KB Large model (Swedish optimized)
+    BergetWhisperKBLarge,
 }
 
 impl TranscriptionModel {
@@ -44,6 +46,7 @@ impl TranscriptionModel {
             | TranscriptionModel::DeepInfraWhisperBase => TranscriptionProvider::DeepInfra,
             TranscriptionModel::GroqWhisperLargeV3
             | TranscriptionModel::GroqWhisperLargeV3Turbo => TranscriptionProvider::Groq,
+            TranscriptionModel::BergetWhisperKBLarge => TranscriptionProvider::Berget,
         }
     }
 
@@ -59,6 +62,7 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase => "deepinfra-whisper-base",
             TranscriptionModel::GroqWhisperLargeV3 => "groq-whisper-large-v3",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "groq-whisper-large-v3-turbo",
+            TranscriptionModel::BergetWhisperKBLarge => "berget-whisper-kb-large",
         }
     }
 
@@ -74,6 +78,7 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase => "Whisper Base (fast, lightweight)",
             TranscriptionModel::GroqWhisperLargeV3 => "Whisper Large V3 (high accuracy)",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "Whisper Large V3 Turbo (fastest)",
+            TranscriptionModel::BergetWhisperKBLarge => "KB Whisper Large (Swedish optimized)",
         }
     }
 
@@ -89,7 +94,12 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperLargeV3
             | TranscriptionModel::DeepInfraWhisperBase => "https://api.deepinfra.com/v1/inference",
             TranscriptionModel::GroqWhisperLargeV3
-            | TranscriptionModel::GroqWhisperLargeV3Turbo => "https://api.groq.com/openai/v1/audio/transcriptions",
+            | TranscriptionModel::GroqWhisperLargeV3Turbo => {
+                "https://api.groq.com/openai/v1/audio/transcriptions"
+            }
+            TranscriptionModel::BergetWhisperKBLarge => {
+                "https://api.berget.ai/v1/audio/transcriptions"
+            }
         }
     }
 
@@ -105,6 +115,7 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase => "openai/whisper-base",
             TranscriptionModel::GroqWhisperLargeV3 => "whisper-large-v3",
             TranscriptionModel::GroqWhisperLargeV3Turbo => "whisper-large-v3-turbo",
+            TranscriptionModel::BergetWhisperKBLarge => "KBLab/kb-whisper-large",
         }
     }
 
@@ -120,6 +131,7 @@ impl TranscriptionModel {
             "deepinfra-whisper-base" => Some(TranscriptionModel::DeepInfraWhisperBase),
             "groq-whisper-large-v3" => Some(TranscriptionModel::GroqWhisperLargeV3),
             "groq-whisper-large-v3-turbo" => Some(TranscriptionModel::GroqWhisperLargeV3Turbo),
+            "berget-whisper-kb-large" => Some(TranscriptionModel::BergetWhisperKBLarge),
             _ => None,
         }
     }
@@ -136,6 +148,7 @@ impl TranscriptionModel {
             TranscriptionModel::DeepInfraWhisperBase,
             TranscriptionModel::GroqWhisperLargeV3,
             TranscriptionModel::GroqWhisperLargeV3Turbo,
+            TranscriptionModel::BergetWhisperKBLarge,
         ]
     }
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -30,8 +30,12 @@ pub enum TranscriptionModel {
     GroqWhisperLargeV3Turbo,
     /// AssemblyAI Universal 3 Pro model (best accuracy)
     AssemblyAIUniversal3Pro,
-    /// Berget Whisper KB Large model (Swedish optimized)
+    /// Berget KB Whisper Large model (Swedish optimized)
     BergetWhisperKBLarge,
+    /// Berget NB Whisper Large model (Norwegian optimized)
+    BergetWhisperNBLarge,
+    /// Berget Whisper Large V3 model (general-purpose, OpenAI)
+    BergetWhisperLargeV3,
 }
 
 impl TranscriptionModel {
@@ -49,7 +53,9 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3
             | TranscriptionModel::GroqWhisperLargeV3Turbo => TranscriptionProvider::Groq,
             TranscriptionModel::AssemblyAIUniversal3Pro => TranscriptionProvider::AssemblyAI,
-            TranscriptionModel::BergetWhisperKBLarge => TranscriptionProvider::Berget,
+            TranscriptionModel::BergetWhisperKBLarge
+            | TranscriptionModel::BergetWhisperNBLarge
+            | TranscriptionModel::BergetWhisperLargeV3 => TranscriptionProvider::Berget,
         }
     }
 
@@ -67,6 +73,8 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3Turbo => "groq-whisper-large-v3-turbo",
             TranscriptionModel::AssemblyAIUniversal3Pro => "assemblyai-universal-3-pro",
             TranscriptionModel::BergetWhisperKBLarge => "berget-whisper-kb-large",
+            TranscriptionModel::BergetWhisperNBLarge => "berget-whisper-nb-large",
+            TranscriptionModel::BergetWhisperLargeV3 => "berget-whisper-large-v3",
         }
     }
 
@@ -84,6 +92,8 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3Turbo => "Whisper Large V3 Turbo (fastest)",
             TranscriptionModel::AssemblyAIUniversal3Pro => "Universal 3 Pro (best accuracy)",
             TranscriptionModel::BergetWhisperKBLarge => "KB Whisper Large (Swedish optimized)",
+            TranscriptionModel::BergetWhisperNBLarge => "NB Whisper Large (Norwegian optimized)",
+            TranscriptionModel::BergetWhisperLargeV3 => "Whisper Large V3 (general-purpose)",
         }
     }
 
@@ -103,7 +113,9 @@ impl TranscriptionModel {
                 "https://api.groq.com/openai/v1/audio/transcriptions"
             }
             TranscriptionModel::AssemblyAIUniversal3Pro => "https://api.assemblyai.com/v2",
-            TranscriptionModel::BergetWhisperKBLarge => {
+            TranscriptionModel::BergetWhisperKBLarge
+            | TranscriptionModel::BergetWhisperNBLarge
+            | TranscriptionModel::BergetWhisperLargeV3 => {
                 "https://api.berget.ai/v1/audio/transcriptions"
             }
         }
@@ -123,6 +135,8 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3Turbo => "whisper-large-v3-turbo",
             TranscriptionModel::AssemblyAIUniversal3Pro => "universal-3-pro",
             TranscriptionModel::BergetWhisperKBLarge => "KBLab/kb-whisper-large",
+            TranscriptionModel::BergetWhisperNBLarge => "NbAiLab/nb-whisper-large",
+            TranscriptionModel::BergetWhisperLargeV3 => "openai/whisper-large-v3",
         }
     }
 
@@ -140,6 +154,8 @@ impl TranscriptionModel {
             "groq-whisper-large-v3-turbo" => Some(TranscriptionModel::GroqWhisperLargeV3Turbo),
             "assemblyai-universal-3-pro" => Some(TranscriptionModel::AssemblyAIUniversal3Pro),
             "berget-whisper-kb-large" => Some(TranscriptionModel::BergetWhisperKBLarge),
+            "berget-whisper-nb-large" => Some(TranscriptionModel::BergetWhisperNBLarge),
+            "berget-whisper-large-v3" => Some(TranscriptionModel::BergetWhisperLargeV3),
             _ => None,
         }
     }
@@ -158,6 +174,8 @@ impl TranscriptionModel {
             TranscriptionModel::GroqWhisperLargeV3Turbo,
             TranscriptionModel::AssemblyAIUniversal3Pro,
             TranscriptionModel::BergetWhisperKBLarge,
+            TranscriptionModel::BergetWhisperNBLarge,
+            TranscriptionModel::BergetWhisperLargeV3,
         ]
     }
 

--- a/src/transcription/provider.rs
+++ b/src/transcription/provider.rs
@@ -12,6 +12,7 @@ pub enum TranscriptionProvider {
     Deepgram,
     DeepInfra,
     Groq,
+    Berget,
 }
 
 impl TranscriptionProvider {
@@ -21,6 +22,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::Deepgram => "deepgram",
             TranscriptionProvider::DeepInfra => "deepinfra",
             TranscriptionProvider::Groq => "groq",
+            TranscriptionProvider::Berget => "berget",
         }
     }
 
@@ -30,6 +32,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::Deepgram => "Deepgram",
             TranscriptionProvider::DeepInfra => "DeepInfra",
             TranscriptionProvider::Groq => "Groq",
+            TranscriptionProvider::Berget => "Berget",
         }
     }
 
@@ -39,6 +42,7 @@ impl TranscriptionProvider {
             "deepgram" => Some(TranscriptionProvider::Deepgram),
             "deepinfra" => Some(TranscriptionProvider::DeepInfra),
             "groq" => Some(TranscriptionProvider::Groq),
+            "berget" => Some(TranscriptionProvider::Berget),
             _ => None,
         }
     }
@@ -49,6 +53,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::Deepgram,
             TranscriptionProvider::DeepInfra,
             TranscriptionProvider::Groq,
+            TranscriptionProvider::Berget,
         ]
     }
 }


### PR DESCRIPTION
This pull request adds support for the Berget transcription provider, specifically the Swedish-optimized KB Whisper Large model, and updates documentation and metadata to reflect this new feature. The implementation includes a new API integration, updates to the model and provider enums, and improvements to the user documentation and contributor list.

**Berget Provider Integration:**

* Added a new module `berget.rs` implementing transcription requests to Berget's OpenAI-compatible Whisper API, handling multipart form data and error parsing.
* Updated `TranscriptionModel` and `TranscriptionProvider` enums and associated methods to support the new `BergetWhisperKBLarge` model and `Berget` provider, including endpoint URLs, display names, and parsing logic. 
* Updated the API dispatch logic in `mod.rs` to call the new Berget transcription function when the provider is selected. 

