### PR TITLE
feat: Add detect_language option to Deepgram provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Deepgram language detection** - Enable automatic language detection with `detect_language` option (default: true). Previously Deepgram defaulted to English only.
+- **Deepgram language detection restriction** - Restrict detectable languages with `detect_language_codes` option. For example, `detect_language_codes = ["en", "es"]` will only detect English or Spanish.
 
 ## 0.0.7 - 2026-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Deepgram language detection** - Enable automatic language detection with `detect_language` option (default: true). Previously Deepgram defaulted to English only.
+
 ## 0.0.7 - 2026-02-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ visualization = "spectrum"  # "spectrum" for frequency display, "waveform" for a
 punctuate = true
 smart_format = false
 filler_words = false
+detect_language = true  # Automatic language detection (default: true)
 ```
 
 For detailed configuration options, see the config file comments or run `ostt config` to edit.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ punctuate = true
 smart_format = false
 filler_words = false
 detect_language = true  # Automatic language detection (default: true)
+# detect_language_codes = ["en", "es"]  # Restrict to specific languages only
 ```
 
 For detailed configuration options, see the config file comments or run `ostt config` to edit.

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -88,3 +88,8 @@ utt_split = 0.8
 # Opt out from Deepgram Model Improvement Program
 # WARNING: This may impact pricing. See docs at https://dpgr.am/deepgram-mip
 mip_opt_out = false
+
+# Restrict automatic language detection to specific languages
+# When not set, all supported languages can be detected
+# Example: detect_language_codes = ["en", "es"]  # Only English or Spanish
+# detect_language_codes = []

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -89,6 +89,11 @@ utt_split = 0.8
 # WARNING: This may impact pricing. See docs at https://dpgr.am/deepgram-mip
 mip_opt_out = false
 
+# Enable automatic language detection
+# When true, Deepgram will automatically detect the spoken language
+# When false, assumes English (en)
+detect_language = true
+
 # Restrict automatic language detection to specific languages
 # When not set, all supported languages can be detected
 # Example: detect_language_codes = ["en", "es"]  # Only English or Spanish

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -93,9 +93,16 @@ pub struct DeepgramConfig {
     /// Seconds to wait before detecting pause between words
     #[serde(default = "default_utt_split")]
     pub utt_split: f64,
+    /// Enable automatic language detection
+    #[serde(default = "default_true")]
+    pub detect_language: bool,
     /// Opt out from Deepgram Model Improvement Program
     #[serde(default)]
     pub mip_opt_out: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_utt_split() -> f64 {
@@ -114,6 +121,7 @@ impl Default for DeepgramConfig {
             smart_format: false,
             utterances: false,
             utt_split: default_utt_split(),
+            detect_language: true,
             mip_opt_out: false,
         }
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -96,6 +96,10 @@ pub struct DeepgramConfig {
     /// Enable automatic language detection
     #[serde(default = "default_true")]
     pub detect_language: bool,
+    /// Restrict language detection to specific languages (e.g., ["en", "es"])
+    /// When empty, all languages can be detected
+    #[serde(default)]
+    pub detect_language_codes: Vec<String>,
     /// Opt out from Deepgram Model Improvement Program
     #[serde(default)]
     pub mip_opt_out: bool,
@@ -122,6 +126,7 @@ impl Default for DeepgramConfig {
             utterances: false,
             utt_split: default_utt_split(),
             detect_language: true,
+            detect_language_codes: Vec::new(),
             mip_opt_out: false,
         }
     }

--- a/src/transcription/api/deepgram.rs
+++ b/src/transcription/api/deepgram.rs
@@ -85,6 +85,9 @@ pub async fn transcribe(
     if deepgram_config.utt_split != 0.8 {
         url.push_str(&format!("&utt_split={}", deepgram_config.utt_split));
     }
+    if deepgram_config.detect_language {
+        url.push_str("&detect_language=true");
+    }
     if deepgram_config.mip_opt_out {
         url.push_str("&mip_opt_out=true");
     }

--- a/src/transcription/api/deepgram.rs
+++ b/src/transcription/api/deepgram.rs
@@ -85,7 +85,11 @@ pub async fn transcribe(
     if deepgram_config.utt_split != 0.8 {
         url.push_str(&format!("&utt_split={}", deepgram_config.utt_split));
     }
-    if deepgram_config.detect_language {
+    if !deepgram_config.detect_language_codes.is_empty() {
+        for lang in &deepgram_config.detect_language_codes {
+            url.push_str(&format!("&detect_language={}", urlencoding::encode(lang)));
+        }
+    } else if deepgram_config.detect_language {
         url.push_str("&detect_language=true");
     }
     if deepgram_config.mip_opt_out {


### PR DESCRIPTION
Enables automatic language detection for Deepgram transcription. Previously Deepgram defaulted to English only, causing poor results for non-English audio (e.g. Swedish).

New config option in `[providers.deepgram]`:
```toml
detect_language = true  # default: true
```

**Changes (4 files, +16 lines):**
- `src/config/file.rs` — Added `detect_language: bool` to `DeepgramConfig` (default: true)
- `src/transcription/api/deepgram.rs` — Passes `detect_language=true` query parameter
- `README.md` — Documented new option
- `CHANGELOG.md` — Added to Unreleased