### PR TITLE
fix: reserve ErrorScreen for TUI commands, use standard errors elsewhere

### DIFF
--- a/src/commands/retry.rs
+++ b/src/commands/retry.rs
@@ -6,7 +6,6 @@ use crate::history::HistoryManager;
 use crate::keywords::KeywordsManager;
 use crate::recording::RecordingHistory;
 use crate::transcription;
-use crate::ui::ErrorScreen;
 use dirs;
 
 /// Retries transcription of a previous recording.
@@ -62,19 +61,10 @@ pub async fn handle_retry(
     );
 
     // Load configuration
-    let config_data = match config::OsttConfig::load() {
-        Ok(config) => config,
-        Err(err) => {
-            tracing::error!("Failed to load configuration: {err}");
-            let error_message = format!(
-                "Configuration Error:\n\n{err}\n\nPlease check your ~/.config/ostt/ostt.toml file and try again."
-            );
-            let mut error_screen = ErrorScreen::new()?;
-            error_screen.show_error(&error_message)?;
-            error_screen.cleanup()?;
-            return Err(anyhow::anyhow!("Configuration error: {err}"));
-        }
-    };
+    let config_data = config::OsttConfig::load().map_err(|err| {
+        tracing::error!("Failed to load configuration: {err}");
+        anyhow::anyhow!("Configuration error: {err}\n\nPlease check your ~/.config/ostt/ostt.toml file and try again.")
+    })?;
 
     // Get the selected model from config
     let selected_model_id = config::get_selected_model().ok().flatten();

--- a/src/commands/transcribe.rs
+++ b/src/commands/transcribe.rs
@@ -8,7 +8,6 @@ use crate::config;
 use crate::history::HistoryManager;
 use crate::keywords::KeywordsManager;
 use crate::transcription;
-use crate::ui::ErrorScreen;
 use dirs;
 use std::path::PathBuf;
 
@@ -39,19 +38,10 @@ pub async fn handle_transcribe(
     tracing::info!("Transcribing file: {}", file.display());
 
     // Load configuration
-    let config_data = match config::OsttConfig::load() {
-        Ok(config) => config,
-        Err(err) => {
-            tracing::error!("Failed to load configuration: {err}");
-            let error_message = format!(
-                "Configuration Error:\n\n{err}\n\nPlease check your ~/.config/ostt/ostt.toml file and try again."
-            );
-            let mut error_screen = ErrorScreen::new()?;
-            error_screen.show_error(&error_message)?;
-            error_screen.cleanup()?;
-            return Err(anyhow::anyhow!("Configuration error: {err}"));
-        }
-    };
+    let config_data = config::OsttConfig::load().map_err(|err| {
+        tracing::error!("Failed to load configuration: {err}");
+        anyhow::anyhow!("Configuration error: {err}\n\nPlease check your ~/.config/ostt/ostt.toml file and try again.")
+    })?;
 
     // Get the selected model from config
     let selected_model_id = config::get_selected_model().ok().flatten();


### PR DESCRIPTION
## Summary

- Remove `ErrorScreen` TUI error display from non-TUI commands (`retry`, `transcribe`)
- Replace with idiomatic anyhow error propagation that prints to stderr
- `ErrorScreen` remains in `record.rs` where the TUI context is appropriate

## Motivation

`ErrorScreen` launches a full-screen ratatui terminal UI to display errors. This makes sense for the `record` command which is already running a TUI, but is unexpected and disruptive for non-interactive, pipeline-friendly commands like `retry` and `transcribe`. These commands should simply print errors to stderr like standard CLI tools.

## Changes

- `src/commands/retry.rs` — replaced `ErrorScreen` config error handling with `.map_err()?`
- `src/commands/transcribe.rs` — replaced `ErrorScreen` config error handling with `.map_err()?`
- Error message content is preserved (users still see the config path hint)