### PR TITLE
Add ARM64 Linux package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,11 +213,21 @@ jobs:
             ${{ env.BUILD_MANIFEST_NAME }}
   # Build .deb and .rpm Linux packages
   build-linux-packages:
-    name: build-linux-packages
+    name: build-linux-packages (${{ matrix.deb_arch }})
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' || github.event_name == 'pull_request' }}
-    runs-on: "ubuntu-22.04"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            deb_arch: amd64
+            rpm_arch: x86_64
+          - runner: ubuntu-22.04-arm
+            deb_arch: arm64
+            rpm_arch: aarch64
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -241,18 +251,18 @@ jobs:
         run: cargo generate-rpm
       - name: Create stable-name copies
         run: |
-          cp target/debian/*.deb target/debian/ostt_latest_amd64.deb
-          cp target/generate-rpm/*.rpm target/generate-rpm/ostt-latest.x86_64.rpm
+          cp target/debian/*.deb target/debian/ostt_latest_${{ matrix.deb_arch }}.deb
+          cp target/generate-rpm/*.rpm target/generate-rpm/ostt-latest.${{ matrix.rpm_arch }}.rpm
       - name: Create package checksums
         run: |
           cd target/debian
-          sha256sum ostt_latest_amd64.deb > ostt_latest_amd64.deb.sha256
+          sha256sum ostt_latest_${{ matrix.deb_arch }}.deb > ostt_latest_${{ matrix.deb_arch }}.deb.sha256
           cd ../generate-rpm
-          sha256sum ostt-latest.x86_64.rpm > ostt-latest.x86_64.rpm.sha256
+          sha256sum ostt-latest.${{ matrix.rpm_arch }}.rpm > ostt-latest.${{ matrix.rpm_arch }}.rpm.sha256
       - name: "Upload Linux packages"
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-linux-packages
+          name: artifacts-linux-packages-${{ matrix.deb_arch }}
           path: |
             target/debian/*.deb
             target/debian/*.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed invalid TOML in the embedded default config template for AssemblyAI language detection options.
 - Suppressed VLC GUI and DBus noise during `ostt replay` on Linux by using terminal-friendly playback commands.
+- Added ARM64 Linux package builds so Ubuntu arm64 users can install a matching `.deb` package.
 
 ## 0.0.9 - 2026-05-12
 


### PR DESCRIPTION
## Summary
- Add a Linux package build matrix for AMD64 and ARM64 runners.
- Publish stable Debian package names for both `ostt_latest_amd64.deb` and `ostt_latest_arm64.deb`.
- Publish architecture-specific RPM stable names for `x86_64` and `aarch64`.

## Notes
- cargo-dist tarball artifacts already include both x86_64 and aarch64 Linux targets.
- The gap was limited to the manually built `.deb` and `.rpm` packages.

## Verification
- `cargo clippy --all-targets --all-features`