### PR TITLE
feat: add Mistral Voxtral transcription provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mistral provider** - New transcription provider with Voxtral Mini Transcribe and Voxtral Mini Transcribe 2 models. Supports optional language hints via `[providers.mistral].language`.
+
 ## 0.0.11 - 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Mistral provider** - New transcription provider with Voxtral Mini Transcribe and Voxtral Mini Transcribe 2 models. Supports optional language hints via `[providers.mistral].language`.
+- **Mistral provider** - New transcription provider with Voxtral Mini Transcribe and Voxtral Mini 2602 models. Supports optional language hints via `[providers.mistral].language`.
 
 ## 0.0.11 - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-OSTT is a terminal-native speech-to-text tool. Record from a hotkey, transcribe with your chosen provider, then send the result to your clipboard, a file, stdout, an AI prompt, or any shell command. It does not assume one vendor, one subscription, or one app-specific workflow: bring your own API key and choose from OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, and ElevenLabs.
+OSTT is a terminal-native speech-to-text tool. Record from a hotkey, transcribe with your chosen provider, then send the result to your clipboard, a file, stdout, an AI prompt, or any shell command. It does not assume one vendor, one subscription, or one app-specific workflow: bring your own API key and choose from OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, ElevenLabs, and Mistral.
 
 OSTT is built for people who treat the terminal as a normal place for voice input to land. You can print to stdout, copy to the clipboard, write to files, retry the same recording with another model, transcribe existing audio, and post-process text with AI prompts or shell commands. Voice becomes text that can move through the same tools as everything else.
 
@@ -36,7 +36,7 @@ OSTT is built for people who treat the terminal as a normal place for voice inpu
 ## Features
 
 - **Linux-first voice input** - Global hotkey setup for Omarchy/Hyprland, GNOME, KDE, and other Linux desktops, with macOS support too.
-- **Provider choice** - Bring your own API key and switch between OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, and ElevenLabs.
+- **Provider choice** - Bring your own API key and switch between OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, ElevenLabs, and Mistral.
 - **Terminal-native workflow** - Use stdout, clipboard, files, aliases, shell completions, logs, and pipes.
 - **Scriptable post-processing** - Transform transcripts with AI prompts or bash commands using `ostt -p` and `ostt process`.
 - **Retry without re-recording** - Save recordings locally, then re-transcribe them with a different provider or model.
@@ -120,7 +120,7 @@ Common aliases: `r` for `record`, `t` for `transcribe`, `l` for `launch`, `p` fo
 
 ## Providers
 
-OSTT is bring-your-own-API-key and currently supports OpenAI, Deepgram, DeepInfra, Groq, AssemblyAI, Berget, and ElevenLabs transcription models.
+OSTT is bring-your-own-API-key and currently supports OpenAI, Deepgram, DeepInfra, Groq, AssemblyAI, Berget, ElevenLabs, and Mistral transcription models.
 
 Run `ostt auth` to select your provider/model and save credentials securely.
 

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -263,3 +263,17 @@ language_detection = true
 # [providers.assemblyai.language_detection_options]
 # expected_languages = ["en", "es", "fr"]  # Only expect these languages
 # fallback_language = "auto"               # "auto" or specific code like "en"
+
+# =============================================================================
+# Mistral Configuration
+# =============================================================================
+
+[providers.mistral]
+
+# Optional language code for transcription.
+# When set, can improve accuracy for known languages.
+# Example: language = "en"   # English
+#          language = "sv"   # Swedish
+#          language = "fr"   # French
+# When not set (or empty), Mistral autodetects the language.
+# language = ""

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -263,17 +263,3 @@ language_detection = true
 # [providers.assemblyai.language_detection_options]
 # expected_languages = ["en", "es", "fr"]  # Only expect these languages
 # fallback_language = "auto"               # "auto" or specific code like "en"
-
-# =============================================================================
-# Mistral Configuration
-# =============================================================================
-
-[providers.mistral]
-
-# Optional language code for transcription.
-# When set, can improve accuracy for known languages.
-# Example: language = "en"   # English
-#          language = "sv"   # Swedish
-#          language = "fr"   # French
-# When not set (or empty), Mistral autodetects the language.
-# language = ""

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -199,6 +199,15 @@ pub struct ElevenLabsConfig {
     pub language_code: Option<String>,
 }
 
+/// Mistral Voxtral API configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MistralConfig {
+    /// Optional language code for transcription (e.g. "en", "sv").
+    /// When set, can improve accuracy for known languages.
+    /// Defaults to null (auto-detect).
+    pub language: Option<String>,
+}
+
 /// Provider-specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProviderConfig {
@@ -221,6 +230,8 @@ pub struct ProvidersConfig {
     pub assemblyai: AssemblyAIConfig,
     #[serde(default)]
     pub elevenlabs: ElevenLabsConfig,
+    #[serde(default)]
+    pub mistral: MistralConfig,
 }
 
 /// Popup window configuration for the `launch` subcommand.

--- a/src/transcription/api/mistral.rs
+++ b/src/transcription/api/mistral.rs
@@ -42,11 +42,21 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
     let debug_params = [format!("model={}", config.model.api_model_name())];
 
     // Add keywords as context_bias for better transcription accuracy
+    // Mistral supports up to 100 words/phrases for context biasing
     if !config.keywords.is_empty() {
         for keyword in &config.keywords {
             form = form.text("context_bias", keyword.clone());
         }
         tracing::debug!("Keywords used as context_bias for Mistral model: {:?}", config.keywords);
+    }
+
+    // Add optional language parameter from provider config
+    let mistral_config = &config.providers.mistral;
+    if let Some(ref lang) = mistral_config.language {
+        if !lang.is_empty() {
+            form = form.text("language", lang.clone());
+            tracing::debug!("Language set for Mistral model: {}", lang);
+        }
     }
 
     let endpoint = config.model.endpoint();

--- a/src/transcription/api/mistral.rs
+++ b/src/transcription/api/mistral.rs
@@ -1,0 +1,116 @@
+//! Mistral Voxtral API implementation.
+//!
+//! Handles transcription requests to Mistral's Voxtral transcription API using
+//! multipart form data. Supports the Voxtral Mini Transcribe model.
+
+use serde::Deserialize;
+use std::path::Path;
+
+use super::TranscriptionConfig;
+
+/// Mistral API response wrapper
+#[derive(Debug, Deserialize)]
+struct MistralResponse {
+    text: String,
+}
+
+/// Transcribes an audio file using Mistral's Voxtral API.
+///
+/// Uses multipart form data with bearer token authentication.
+/// Keywords are passed as the `context_bias` parameter to improve transcription
+/// accuracy for domain-specific terms.
+pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyhow::Result<String> {
+    let audio_data =
+        std::fs::read(audio_path).map_err(|e| anyhow::anyhow!("Failed to read audio file: {e}"))?;
+
+    let file_name = audio_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let file_part = reqwest::multipart::Part::bytes(audio_data)
+        .file_name(file_name)
+        .mime_str("audio/mpeg")
+        .map_err(|e| anyhow::anyhow!("Failed to create file part for upload: {e}"))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", file_part)
+        .text("model", config.model.api_model_name().to_string());
+
+    // Debug log: Log the API call details (without the audio data)
+    let debug_params = [format!("model={}", config.model.api_model_name())];
+
+    // Add keywords as context_bias for better transcription accuracy
+    if !config.keywords.is_empty() {
+        for keyword in &config.keywords {
+            form = form.text("context_bias", keyword.clone());
+        }
+        tracing::debug!("Keywords used as context_bias for Mistral model: {:?}", config.keywords);
+    }
+
+    let endpoint = config.model.endpoint();
+
+    let client = reqwest::Client::new();
+
+    tracing::debug!(
+        "Mistral API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",
+        endpoint,
+        debug_params.join("\n    ")
+    );
+
+    let response = match client
+        .post(endpoint)
+        .bearer_auth(&config.api_key)
+        .multipart(form)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            let error_msg = if e.is_connect() {
+                "Failed to connect to Mistral API server. Check your internet connection."
+                    .to_string()
+            } else if e.is_timeout() {
+                "Request to Mistral timed out. The API server is not responding.".to_string()
+            } else if e.to_string().contains("builder") {
+                format!("Failed to build Mistral API request: {e}. This may be a configuration error.")
+            } else {
+                format!("Mistral network error: {e}")
+            };
+            return Err(anyhow::anyhow!(error_msg));
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+
+        let human_readable = match status.as_u16() {
+            401 => "Mistral API key is invalid or expired. Please run 'ostt auth' to update your API key.".to_string(),
+            403 => "You don't have permission to use Mistral's API. Check your API key and account status.".to_string(),
+            429 => "Too many requests to Mistral. You've hit the API rate limit. Please wait and try again.".to_string(),
+            500 | 502 | 503 | 504 => "Mistral API server is experiencing issues. Please try again later.".to_string(),
+            _ => format!("Mistral API error (status {status}): {error_body}"),
+        };
+
+        return Err(anyhow::anyhow!(human_readable));
+    }
+
+    let mistral_response: MistralResponse = response
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to parse Mistral response: {e}"))?;
+
+    // Debug log: Log the full response for debugging
+    tracing::debug!(
+        "Mistral API Response:\n  Status: Success\n  Transcription length: {} characters\n  Full response: {:#?}",
+        mistral_response.text.len(),
+        mistral_response
+    );
+
+    Ok(mistral_response.text.trim().to_string())
+}

--- a/src/transcription/api/mistral.rs
+++ b/src/transcription/api/mistral.rs
@@ -47,7 +47,10 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
         for keyword in &config.keywords {
             form = form.text("context_bias", keyword.clone());
         }
-        tracing::debug!("Keywords used as context_bias for Mistral model: {:?}", config.keywords);
+        tracing::debug!(
+            "Keywords used as context_bias for Mistral model: {:?}",
+            config.keywords
+        );
     }
 
     // Add optional language parameter from provider config
@@ -84,7 +87,9 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
             } else if e.is_timeout() {
                 "Request to Mistral timed out. The API server is not responding.".to_string()
             } else if e.to_string().contains("builder") {
-                format!("Failed to build Mistral API request: {e}. This may be a configuration error.")
+                format!(
+                    "Failed to build Mistral API request: {e}. This may be a configuration error."
+                )
             } else {
                 format!("Mistral network error: {e}")
             };

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -10,6 +10,7 @@ mod deepgram;
 mod deepinfra;
 mod elevenlabs;
 mod groq;
+mod mistral;
 mod openai;
 
 use serde::Deserialize;
@@ -81,6 +82,7 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
         TranscriptionProvider::AssemblyAI => assemblyai::transcribe(config, audio_path).await,
         TranscriptionProvider::Berget => berget::transcribe(config, audio_path).await,
         TranscriptionProvider::ElevenLabs => elevenlabs::transcribe(config, audio_path).await,
+        TranscriptionProvider::Mistral => mistral::transcribe(config, audio_path).await,
     }?;
 
     Ok(result)

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -40,6 +40,8 @@ pub enum TranscriptionModel {
     ElevenLabsScribeV2,
     /// ElevenLabs Scribe v1 model (previous generation)
     ElevenLabsScribeV1,
+    /// Mistral Voxtral Mini Transcribe model (fast, efficient, 13 languages)
+    MistralVoxtralMiniTranscribe,
 }
 
 impl TranscriptionModel {
@@ -63,6 +65,7 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 | TranscriptionModel::ElevenLabsScribeV1 => {
                 TranscriptionProvider::ElevenLabs
             }
+            TranscriptionModel::MistralVoxtralMiniTranscribe => TranscriptionProvider::Mistral,
         }
     }
 
@@ -84,6 +87,7 @@ impl TranscriptionModel {
             TranscriptionModel::BergetWhisperLargeV3 => "berget-whisper-large-v3",
             TranscriptionModel::ElevenLabsScribeV2 => "elevenlabs-scribe-v2",
             TranscriptionModel::ElevenLabsScribeV1 => "elevenlabs-scribe-v1",
+            TranscriptionModel::MistralVoxtralMiniTranscribe => "mistral-voxtral-mini",
         }
     }
 
@@ -105,6 +109,9 @@ impl TranscriptionModel {
             TranscriptionModel::BergetWhisperLargeV3 => "Whisper Large V3 (general-purpose)",
             TranscriptionModel::ElevenLabsScribeV2 => "Scribe v2 (highest accuracy, 99 languages)",
             TranscriptionModel::ElevenLabsScribeV1 => "Scribe v1 (previous generation)",
+            TranscriptionModel::MistralVoxtralMiniTranscribe => {
+                "Voxtral Mini Transcribe (fast, efficient, 13 languages)"
+            }
         }
     }
 
@@ -132,6 +139,9 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 | TranscriptionModel::ElevenLabsScribeV1 => {
                 "https://api.elevenlabs.io/v1/speech-to-text"
             }
+            TranscriptionModel::MistralVoxtralMiniTranscribe => {
+                "https://api.mistral.ai/v1/audio/transcriptions"
+            }
         }
     }
 
@@ -153,6 +163,7 @@ impl TranscriptionModel {
             TranscriptionModel::BergetWhisperLargeV3 => "openai/whisper-large-v3",
             TranscriptionModel::ElevenLabsScribeV2 => "scribe_v2",
             TranscriptionModel::ElevenLabsScribeV1 => "scribe_v1",
+            TranscriptionModel::MistralVoxtralMiniTranscribe => "voxtral-mini-latest",
         }
     }
 
@@ -174,6 +185,7 @@ impl TranscriptionModel {
             "berget-whisper-large-v3" => Some(TranscriptionModel::BergetWhisperLargeV3),
             "elevenlabs-scribe-v2" => Some(TranscriptionModel::ElevenLabsScribeV2),
             "elevenlabs-scribe-v1" => Some(TranscriptionModel::ElevenLabsScribeV1),
+            "mistral-voxtral-mini" => Some(TranscriptionModel::MistralVoxtralMiniTranscribe),
             _ => None,
         }
     }
@@ -196,6 +208,7 @@ impl TranscriptionModel {
             TranscriptionModel::BergetWhisperLargeV3,
             TranscriptionModel::ElevenLabsScribeV2,
             TranscriptionModel::ElevenLabsScribeV1,
+            TranscriptionModel::MistralVoxtralMiniTranscribe,
         ]
     }
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -42,6 +42,8 @@ pub enum TranscriptionModel {
     ElevenLabsScribeV1,
     /// Mistral Voxtral Mini Transcribe model (fast, efficient, 13 languages)
     MistralVoxtralMiniTranscribe,
+    /// Mistral Voxtral Mini Transcribe 2 model (newer version, improved accuracy)
+    MistralVoxtralMiniTranscribeV2,
 }
 
 impl TranscriptionModel {
@@ -65,7 +67,8 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 | TranscriptionModel::ElevenLabsScribeV1 => {
                 TranscriptionProvider::ElevenLabs
             }
-            TranscriptionModel::MistralVoxtralMiniTranscribe => TranscriptionProvider::Mistral,
+            TranscriptionModel::MistralVoxtralMiniTranscribe
+            | TranscriptionModel::MistralVoxtralMiniTranscribeV2 => TranscriptionProvider::Mistral,
         }
     }
 
@@ -88,6 +91,7 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 => "elevenlabs-scribe-v2",
             TranscriptionModel::ElevenLabsScribeV1 => "elevenlabs-scribe-v1",
             TranscriptionModel::MistralVoxtralMiniTranscribe => "mistral-voxtral-mini",
+            TranscriptionModel::MistralVoxtralMiniTranscribeV2 => "mistral-voxtral-mini-v2",
         }
     }
 
@@ -111,6 +115,9 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV1 => "Scribe v1 (previous generation)",
             TranscriptionModel::MistralVoxtralMiniTranscribe => {
                 "Voxtral Mini Transcribe (fast, efficient, 13 languages)"
+            }
+            TranscriptionModel::MistralVoxtralMiniTranscribeV2 => {
+                "Voxtral Mini Transcribe 2 (newer, improved accuracy)"
             }
         }
     }
@@ -139,7 +146,8 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 | TranscriptionModel::ElevenLabsScribeV1 => {
                 "https://api.elevenlabs.io/v1/speech-to-text"
             }
-            TranscriptionModel::MistralVoxtralMiniTranscribe => {
+            TranscriptionModel::MistralVoxtralMiniTranscribe
+            | TranscriptionModel::MistralVoxtralMiniTranscribeV2 => {
                 "https://api.mistral.ai/v1/audio/transcriptions"
             }
         }
@@ -164,6 +172,7 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 => "scribe_v2",
             TranscriptionModel::ElevenLabsScribeV1 => "scribe_v1",
             TranscriptionModel::MistralVoxtralMiniTranscribe => "voxtral-mini-latest",
+            TranscriptionModel::MistralVoxtralMiniTranscribeV2 => "voxtral-mini-transcribe-26-02",
         }
     }
 
@@ -186,6 +195,7 @@ impl TranscriptionModel {
             "elevenlabs-scribe-v2" => Some(TranscriptionModel::ElevenLabsScribeV2),
             "elevenlabs-scribe-v1" => Some(TranscriptionModel::ElevenLabsScribeV1),
             "mistral-voxtral-mini" => Some(TranscriptionModel::MistralVoxtralMiniTranscribe),
+            "mistral-voxtral-mini-v2" => Some(TranscriptionModel::MistralVoxtralMiniTranscribeV2),
             _ => None,
         }
     }
@@ -209,6 +219,7 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2,
             TranscriptionModel::ElevenLabsScribeV1,
             TranscriptionModel::MistralVoxtralMiniTranscribe,
+            TranscriptionModel::MistralVoxtralMiniTranscribeV2,
         ]
     }
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -42,7 +42,7 @@ pub enum TranscriptionModel {
     ElevenLabsScribeV1,
     /// Mistral Voxtral Mini Transcribe model (fast, efficient, 13 languages)
     MistralVoxtralMiniTranscribe,
-    /// Mistral Voxtral Mini Transcribe 2 model (newer version, improved accuracy)
+    /// Mistral Voxtral Mini 2602 model (pinned version)
     MistralVoxtralMiniTranscribeV2,
 }
 
@@ -117,7 +117,7 @@ impl TranscriptionModel {
                 "Voxtral Mini Transcribe (fast, efficient, 13 languages)"
             }
             TranscriptionModel::MistralVoxtralMiniTranscribeV2 => {
-                "Voxtral Mini Transcribe 2 (newer, improved accuracy)"
+                "Voxtral Mini 2602 (newer version, improved accuracy)"
             }
         }
     }
@@ -172,7 +172,7 @@ impl TranscriptionModel {
             TranscriptionModel::ElevenLabsScribeV2 => "scribe_v2",
             TranscriptionModel::ElevenLabsScribeV1 => "scribe_v1",
             TranscriptionModel::MistralVoxtralMiniTranscribe => "voxtral-mini-latest",
-            TranscriptionModel::MistralVoxtralMiniTranscribeV2 => "voxtral-mini-transcribe-26-02",
+            TranscriptionModel::MistralVoxtralMiniTranscribeV2 => "voxtral-mini-2602",
         }
     }
 

--- a/src/transcription/provider.rs
+++ b/src/transcription/provider.rs
@@ -15,6 +15,7 @@ pub enum TranscriptionProvider {
     AssemblyAI,
     Berget,
     ElevenLabs,
+    Mistral,
 }
 
 impl TranscriptionProvider {
@@ -27,6 +28,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::AssemblyAI => "assemblyai",
             TranscriptionProvider::Berget => "berget",
             TranscriptionProvider::ElevenLabs => "elevenlabs",
+            TranscriptionProvider::Mistral => "mistral",
         }
     }
 
@@ -39,6 +41,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::AssemblyAI => "AssemblyAI",
             TranscriptionProvider::Berget => "Berget",
             TranscriptionProvider::ElevenLabs => "ElevenLabs",
+            TranscriptionProvider::Mistral => "Mistral",
         }
     }
 
@@ -51,6 +54,7 @@ impl TranscriptionProvider {
             "assemblyai" => Some(TranscriptionProvider::AssemblyAI),
             "berget" => Some(TranscriptionProvider::Berget),
             "elevenlabs" => Some(TranscriptionProvider::ElevenLabs),
+            "mistral" => Some(TranscriptionProvider::Mistral),
             _ => None,
         }
     }
@@ -64,6 +68,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::AssemblyAI,
             TranscriptionProvider::Berget,
             TranscriptionProvider::ElevenLabs,
+            TranscriptionProvider::Mistral,
         ]
     }
 }


### PR DESCRIPTION
Adds support for Mistral's Voxtral transcription models via the `audio/transcriptions` API endpoint.

## Changes
- **New provider**: `Mistral` — uses Mistral AI API keys
- **New models**:
  - `MistralVoxtralMiniTranscribe` (`mistral-voxtral-mini`) — Voxtral Mini Transcribe (`voxtral-mini-latest`), fast and efficient with support for 13 languages
  - `MistralVoxtralMiniTranscribeV2` (`mistral-voxtral-mini-v2`) — Voxtral Mini Transcribe 2 (`voxtral-mini-transcribe-26-02`), newer version with improved accuracy
- **API implementation**: `src/transcription/api/mistral.rs` — multipart form upload with Bearer token auth
- **Parameters**:
  - `context_bias` — keywords are passed as `context_bias` (up to 100 words/phrases)
  - `language` — optional language code via provider config (`[providers.mistral]` in ostt.toml)
- **Wired up** in provider, model, and API dispatch

## Config example
```toml
[providers.mistral]
language = "en"
```

## Testing
- `cargo check`: ✅ 
- `cargo clippy`: ✅ (no warnings)

Closes #56