### PR TITLE
Kde device debug

### DIFF
--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -101,7 +101,7 @@ pub async fn handle_record(
         match tui.handle_input() {
             Ok(RecordingCommand::Continue) => {
                 frame_count += 1;
-                if frame_count.is_multiple_of(60) {
+                if frame_count % 60 == 0 {
                     let sample_count = audio_recorder.sample_count();
                     let duration_secs = sample_count as f32 / actual_sample_rate as f32;
                     tracing::debug!("Recording: {:.1}s recorded", duration_secs);

--- a/src/recording/audio.rs
+++ b/src/recording/audio.rs
@@ -8,7 +8,6 @@ use super::ffmpeg::find_ffmpeg;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use hound::WavWriter;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -65,7 +64,7 @@ impl AudioRecorder {
         }
     }
 
-    fn try_start_with_device(&mut self, device: cpal::Device, probe: bool) -> Result<()> {
+    fn try_start_with_device(&mut self, device: cpal::Device) -> Result<()> {
         let device_name = device
             .name()
             .unwrap_or_else(|_| "Unknown device".to_string());
@@ -116,11 +115,10 @@ impl AudioRecorder {
         // Start playback and store stream
         stream.play()?;
 
-        if probe {
-            std::thread::sleep(Duration::from_millis(PROBE_DURATION_MS));
-            if !has_samples.load(Ordering::Relaxed) {
-                return Err(anyhow!("Audio probe timed out (no samples)"));
-            }
+        // Probe for a short duration to ensure the device is producing samples
+        std::thread::sleep(Duration::from_millis(PROBE_DURATION_MS));
+        if !has_samples.load(Ordering::Relaxed) {
+            return Err(anyhow!("Audio probe timed out (no samples)"));
         }
 
         self.stream = Some(stream);
@@ -155,25 +153,14 @@ impl AudioRecorder {
             return Err(anyhow!("No audio input device available"));
         }
 
-        // Explicit device selection: no fallback
-        if self.device_name != "default" {
-            return self.try_start_with_device(
-                candidates
-                    .into_iter()
-                    .next()
-                    .expect("Candidates list should be non-empty"),
-                false,
-            );
-        }
-
-        // Default device selection: fallback through all available inputs
+        // Attempt to start recording with the first suitable device
         let mut last_err: Option<anyhow::Error> = None;
         for device in candidates {
             let device_name = device
                 .name()
                 .unwrap_or_else(|_| "Unknown device".to_string());
 
-            match self.try_start_with_device(device, true) {
+            match self.try_start_with_device(device) {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     tracing::warn!(
@@ -429,10 +416,6 @@ impl AudioRecorder {
     }
 }
 
-fn device_name_key(device: &cpal::Device) -> String {
-    device.name().unwrap_or_else(|_| "Unknown".to_string())
-}
-
 fn collect_default_then_inputs(host: &cpal::Host) -> Result<Vec<cpal::Device>> {
     let mut devices = Vec::new();
 
@@ -447,17 +430,6 @@ fn collect_default_then_inputs(host: &cpal::Host) -> Result<Vec<cpal::Device>> {
     for dev in input_devices {
         devices.push(dev);
     }
-
-    let mut seen = HashSet::new();
-    devices.retain(|d| {
-        let name = device_name_key(d);
-        if seen.contains(&name) {
-            false
-        } else {
-            seen.insert(name);
-            true
-        }
-    });
 
     Ok(devices)
 }

--- a/src/recording/audio.rs
+++ b/src/recording/audio.rs
@@ -12,11 +12,15 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 #[cfg(target_os = "linux")]
 use std::fs::OpenOptions;
 #[cfg(target_os = "linux")]
 use std::os::unix::io::AsRawFd;
+
+const PROBE_DURATION_MS: u64 = 300;
 
 /// Records audio from a specified or default input device.
 ///
@@ -61,11 +65,10 @@ impl AudioRecorder {
         }
     }
 
-    fn try_start_with_device(&mut self, device: cpal::Device) -> Result<()> {
+    fn try_start_with_device(&mut self, device: cpal::Device, probe: bool) -> Result<()> {
         let device_name = device
             .name()
             .unwrap_or_else(|_| "Unknown device".to_string());
-        tracing::debug!("Trying recording device: {}", device_name);
 
         let device_config = device.default_input_config()?;
         let device_sample_rate = device_config.sample_rate().0;
@@ -90,12 +93,17 @@ impl AudioRecorder {
         let samples_arc = Arc::clone(&self.samples);
         let pause_arc = Arc::clone(&self.is_paused);
         let callback_channels = num_channels;
+        let has_samples = Arc::new(AtomicBool::new(false));
+        let has_samples_clone = Arc::clone(&has_samples);
 
         let stream = device.build_input_stream(
             &device_config.into(),
             move |data: &[i16], _: &cpal::InputCallbackInfo| {
                 let is_paused = *pause_arc.lock().unwrap();
                 if !is_paused {
+                    if !data.is_empty() {
+                        has_samples_clone.store(true, Ordering::Relaxed);
+                    }
                     Self::handle_audio_callback(data, &samples_arc, callback_channels);
                 }
             },
@@ -107,6 +115,14 @@ impl AudioRecorder {
 
         // Start playback and store stream
         stream.play()?;
+
+        if probe {
+            std::thread::sleep(Duration::from_millis(PROBE_DURATION_MS));
+            if !has_samples.load(Ordering::Relaxed) {
+                return Err(anyhow!("Audio probe timed out (no samples)"));
+            }
+        }
+
         self.stream = Some(stream);
         self.sample_rate = device_sample_rate;
         self.device_channels = num_channels;
@@ -146,6 +162,7 @@ impl AudioRecorder {
                     .into_iter()
                     .next()
                     .expect("Candidates list should be non-empty"),
+                false,
             );
         }
 
@@ -156,7 +173,7 @@ impl AudioRecorder {
                 .name()
                 .unwrap_or_else(|_| "Unknown device".to_string());
 
-            match self.try_start_with_device(device) {
+            match self.try_start_with_device(device, true) {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     tracing::warn!(

--- a/src/recording/audio.rs
+++ b/src/recording/audio.rs
@@ -132,19 +132,15 @@ impl AudioRecorder {
 
     /// Starts recording from the configured input device.
     ///
-    /// # Errors
-    /// - If the specified device is not available
-    /// - If device configuration fails
-    /// - If audio stream creation fails
     pub fn start_recording(&mut self) -> Result<()> {
-        // Get devices while suppressing ALSA library warnings
+        // If device is set to "default", get a list of candidates
+        // If a device name is set, try to find it by name (one candidate)
         let candidates = suppress_alsa_warnings(|| {
             let host = cpal::default_host();
 
             if self.device_name == "default" {
                 collect_default_then_inputs(&host)
             } else {
-                // Try to find device by name or index
                 Ok(vec![find_device_by_name(&host, &self.device_name)?])
             }
         })?;
@@ -153,7 +149,7 @@ impl AudioRecorder {
             return Err(anyhow!("No audio input device available"));
         }
 
-        // Attempt to start recording with the first suitable device
+        // Attempt to record with candidate devices until one works
         let mut last_err: Option<anyhow::Error> = None;
         for device in candidates {
             let device_name = device
@@ -416,6 +412,7 @@ impl AudioRecorder {
     }
 }
 
+/// Collects the default input device followed by all other input devices.
 fn collect_default_then_inputs(host: &cpal::Host) -> Result<Vec<cpal::Device>> {
     let mut devices = Vec::new();
 
@@ -439,9 +436,6 @@ fn collect_default_then_inputs(host: &cpal::Host) -> Result<Vec<cpal::Device>> {
 /// # Arguments
 /// * `host` - The cpal audio host
 /// * `device_spec` - Either "default" for system default, a device name, or a numeric index (0, 1, 2, etc.)
-///
-/// # Errors
-/// - If no device with the specified name/index is found
 fn find_device_by_name(host: &cpal::Host, device_spec: &str) -> Result<cpal::Device> {
     // Try to parse as a numeric index first
     if let Ok(index) = device_spec.parse::<usize>() {

--- a/src/recording/audio.rs
+++ b/src/recording/audio.rs
@@ -8,6 +8,7 @@ use super::ffmpeg::find_ffmpeg;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use hound::WavWriter;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -60,30 +61,11 @@ impl AudioRecorder {
         }
     }
 
-    /// Starts recording from the configured input device.
-    ///
-    /// # Errors
-    /// - If the specified device is not available
-    /// - If device configuration fails
-    /// - If audio stream creation fails
-    pub fn start_recording(&mut self) -> Result<()> {
-        // Get device while suppressing ALSA library warnings
-        let device = suppress_alsa_warnings(|| {
-            let host = cpal::default_host();
-
-            if self.device_name == "default" {
-                host.default_input_device()
-                    .ok_or_else(|| anyhow!("No audio input device available"))
-            } else {
-                // Try to find device by name or index
-                find_device_by_name(&host, &self.device_name)
-            }
-        })?;
-
+    fn try_start_with_device(&mut self, device: cpal::Device) -> Result<()> {
         let device_name = device
             .name()
             .unwrap_or_else(|_| "Unknown device".to_string());
-        tracing::info!("Recording device: {}", device_name);
+        tracing::debug!("Trying recording device: {}", device_name);
 
         let device_config = device.default_input_config()?;
         let device_sample_rate = device_config.sample_rate().0;
@@ -103,10 +85,6 @@ impl AudioRecorder {
             device_sample_rate,
             num_channels
         );
-
-        // Update to actual device parameters
-        self.sample_rate = device_sample_rate;
-        self.device_channels = num_channels;
 
         // Set up audio callback with cloned Arc references
         let samples_arc = Arc::clone(&self.samples);
@@ -130,9 +108,68 @@ impl AudioRecorder {
         // Start playback and store stream
         stream.play()?;
         self.stream = Some(stream);
+        self.sample_rate = device_sample_rate;
+        self.device_channels = num_channels;
 
+        tracing::info!("Recording device: {}", device_name);
         tracing::debug!("Audio stream started");
         Ok(())
+    }
+
+    /// Starts recording from the configured input device.
+    ///
+    /// # Errors
+    /// - If the specified device is not available
+    /// - If device configuration fails
+    /// - If audio stream creation fails
+    pub fn start_recording(&mut self) -> Result<()> {
+        // Get devices while suppressing ALSA library warnings
+        let candidates = suppress_alsa_warnings(|| {
+            let host = cpal::default_host();
+
+            if self.device_name == "default" {
+                collect_default_then_inputs(&host)
+            } else {
+                // Try to find device by name or index
+                Ok(vec![find_device_by_name(&host, &self.device_name)?])
+            }
+        })?;
+
+        if candidates.is_empty() {
+            return Err(anyhow!("No audio input device available"));
+        }
+
+        // Explicit device selection: no fallback
+        if self.device_name != "default" {
+            return self.try_start_with_device(
+                candidates
+                    .into_iter()
+                    .next()
+                    .expect("Candidates list should be non-empty"),
+            );
+        }
+
+        // Default device selection: fallback through all available inputs
+        let mut last_err: Option<anyhow::Error> = None;
+        for device in candidates {
+            let device_name = device
+                .name()
+                .unwrap_or_else(|_| "Unknown device".to_string());
+
+            match self.try_start_with_device(device) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to start recording on device {}: {}",
+                        device_name,
+                        e
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| anyhow!("No usable audio input device found")))
     }
 
     /// Stops recording and saves audio to the specified output file.
@@ -373,6 +410,39 @@ impl AudioRecorder {
     pub fn get_sample_rate(&self) -> u32 {
         self.sample_rate()
     }
+}
+
+fn device_name_key(device: &cpal::Device) -> String {
+    device.name().unwrap_or_else(|_| "Unknown".to_string())
+}
+
+fn collect_default_then_inputs(host: &cpal::Host) -> Result<Vec<cpal::Device>> {
+    let mut devices = Vec::new();
+
+    if let Some(default_dev) = host.default_input_device() {
+        devices.push(default_dev);
+    }
+
+    let input_devices = host
+        .input_devices()
+        .map_err(|e| anyhow!("Failed to enumerate devices: {e}"))?;
+
+    for dev in input_devices {
+        devices.push(dev);
+    }
+
+    let mut seen = HashSet::new();
+    devices.retain(|d| {
+        let name = device_name_key(d);
+        if seen.contains(&name) {
+            false
+        } else {
+            seen.insert(name);
+            true
+        }
+    });
+
+    Ok(devices)
 }
 
 /// Finds an audio input device by name or numeric index.


### PR DESCRIPTION
Solution for https://github.com/kristoferlund/ostt/issues/58

This is a fallback mechanism, it should not make any difference for setups that already work.

With this change, OSTT will now probe that there are actually samples coming from the recording device, and raise an error if there aren't. If device is set to `default` in the config, it will then try other available devices until one works.

