### PR TITLE
Refine CLI command structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added per-run transcription model selection with `-m, --model <PROVIDER/MODEL>` for `ostt`, `ostt record`, `ostt transcribe`, `ostt retry`, and `ostt launch`. The override applies only to the current invocation and does not change the saved default model.
+- Added scriptable CLI actions for models, keywords, auth, history, config helpers, logs, and local model download/removal.
 
 ### Changed
 
 - Cloud transcription models now use provider/model identities such as `deepgram/nova-3`, `deepinfra/openai/whisper-large-v3`, and `berget/KBLab/kb-whisper-large`, replacing older OSTT-invented model IDs.
 - Local model UI and error messages now show full public IDs such as `local/turbo`.
+- Cleaned up command syntax: `ostt keyword` replaces `ostt keywords`, `ostt config list-devices` replaces `ostt list-devices`, `ostt process list` replaces `ostt process --list`, and `ostt completions install <shell>` replaces `ostt completions <shell> --install`.
+- Record-only options no longer appear in unrelated management command help.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you prefer platform package managers, see the docs for Homebrew, AUR, `.deb`,
 ## Quick Start
 
 ```bash
-ostt auth           # Choose provider/model and save API key
+ostt auth           # Save cloud provider credentials
 ostt model          # Choose cloud or local transcription model
 ostt                # Record, transcribe, print to stdout
 ostt -c             # Record, transcribe, copy to clipboard
@@ -93,7 +93,7 @@ ostt launch -c -p clean       # Popup hotkey workflow with processing
 ostt process                  # Process most recent history item, show picker
 ostt process clean            # Process most recent history item with clean action
 ostt process 3 clean -c       # Process history item #3 with clean action
-ostt process --list           # List configured actions
+ostt process list             # List configured actions
 ```
 
 Actions are configured in `~/.config/ostt/ostt.toml` and can run either bash commands or AI CLI tools. See [Processing Actions](https://ostt.ai/guide/processing) for examples.
@@ -111,17 +111,17 @@ ostt retry 2 -m groq/whisper-large-v3 -c
 ostt replay                  # Play most recent recording
 ostt model                   # Choose cloud or local transcription model
 ostt history                 # Browse transcription history
-ostt keywords                # Manage transcription keywords
+ostt keyword                 # Manage transcription keywords
 ostt config                  # Open config file
-ostt list-devices            # List audio input devices
+ostt config list-devices     # List audio input devices
 ostt logs                    # View recent logs
 ostt completions zsh         # Generate shell completions
-ostt completions bash --install  # Install completions system-wide
+ostt completions install bash    # Install completions system-wide
 ostt --version               # Show version
 ostt --help                  # Show help
 ```
 
-Common aliases: `r` for `record`, `t` for `transcribe`, `l` for `launch`, `p` for `process`, `a` for `auth`, `h` for `history`, `k` for `keywords`, `c` for `config`, and `rp` for `replay`.
+Common aliases: `r` for `record`, `t` for `transcribe`, `l` for `launch`, `p` for `process`, `a` for `auth`, `h` for `history`, `k` for `keyword`, `c` for `config`, and `rp` for `replay`.
 
 ## Providers
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@
 use crate::commands;
 use crate::logging;
 use anyhow::anyhow;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
 use std::env;
 use std::fs;
@@ -88,18 +88,18 @@ fn load_config() -> anyhow::Result<crate::config::OsttConfig> {
 #[command(version)]
 #[command(about = "\n\n ┏┓┏╋╋ \n ┗┛┛┗┗")]
 #[command(
-    long_about = "\n\n ┏┓┏╋╋ \n ┗┛┛┗┗\n\nA terminal-based speech-to-text recorder with real-time waveform visualization\nand automatic transcription support.\n\nDEFAULT COMMAND:\n    If no command is specified, 'record' is used by default.\n    Record options (-c, -o) can be used without explicitly saying 'record'.\n\nEXAMPLES:\n    # Record and pipe to other command (default stdout)\n    $ ostt | grep word\n    $ ostt record | grep word\n    \n    # Record and copy to clipboard\n    $ ostt -c\n    $ ostt record -c\n    $ ostt -m deepgram/nova-3 -c\n    \n    # Record and write to file\n    $ ostt -o output.txt\n    $ ostt record -o output.txt\n    \n    # Retry most recent recording and pipe output\n    $ ostt retry | wc -w\n    \n    # Retry recording #2 and copy to clipboard\n    $ ostt retry 2 -c\n    \n    # Transcribe a pre-recorded audio file\n    $ ostt transcribe recording.ogg\n    $ ostt transcribe recording.ogg -m openai/gpt-4o-transcribe\n    \n    # Transcribe and copy to clipboard\n    $ ostt transcribe voice-memo.mp3 -c\n    \n    # Set up authentication for cloud providers\n    $ ostt auth\n    \n    # Choose cloud or local transcription model\n    $ ostt model\n    \n    # View your transcription history\n    $ ostt history\n    \n    # Edit configuration file\n    $ ostt config"
+    long_about = "\n\n ┏┓┏╋╋ \n ┗┛┛┗┗\n\nA terminal-based speech-to-text recorder with real-time waveform visualization\nand automatic transcription support.\n\nDEFAULT COMMAND:\n    If no command is specified, 'record' is used by default.\n    Record options (-c, -o) can be used without explicitly saying 'record'.\n\nEXAMPLES:\n    # Record and pipe to other command (default stdout)\n    $ ostt | grep word\n    $ ostt record | grep word\n    \n    # Record and copy to clipboard\n    $ ostt -c\n    $ ostt record -c\n    $ ostt -m deepgram/nova-3 -c\n    \n    # Record and write to file\n    $ ostt -o output.txt\n    $ ostt record -o output.txt\n    \n    # Retry most recent recording and pipe output\n    $ ostt retry | wc -w\n    \n    # Retry recording #2 and copy to clipboard\n    $ ostt retry 2 -c\n    \n    # Transcribe a pre-recorded audio file\n    $ ostt transcribe recording.ogg\n    $ ostt transcribe recording.ogg -m openai/gpt-4o-transcribe\n    \n    # Transcribe and copy to clipboard\n    $ ostt transcribe voice-memo.mp3 -c\n    \n    # Set up authentication for cloud providers\n    $ ostt auth\n    \n    # Choose cloud or local transcription model\n    $ ostt model\n    \n    # View your transcription history\n    $ ostt history\n    \n    # Manage transcription keywords\n    $ ostt keyword\n    \n    # Edit configuration file\n    $ ostt config"
 )]
 #[command(
     after_help = "CONFIGURATION:\n    Config file:        ~/.config/ostt/ostt.toml\n    Logs:               ~/.local/state/ostt/ostt.log.*\n\nFor more information, visit: https://github.com/kristoferlund/ostt"
 )]
 struct Cli {
     /// Copy transcription to clipboard instead of stdout (record default command)
-    #[arg(short, long, global = true)]
+    #[arg(short, long)]
     clipboard: bool,
 
     /// Write transcription to file instead of stdout (record default command)
-    #[arg(short, long, value_name = "FILE", global = true)]
+    #[arg(short, long, value_name = "FILE")]
     output: Option<String>,
 
     /// Enable processing after transcription
@@ -107,16 +107,23 @@ struct Cli {
     process: Option<String>,
 
     /// Override transcription model for this run
-    #[arg(
-        short = 'm',
-        long = "model",
-        value_name = "PROVIDER/MODEL",
-        global = true
-    )]
+    #[arg(short = 'm', long = "model", value_name = "PROVIDER/MODEL")]
     model: Option<String>,
 
     #[command(subcommand)]
     command: Option<Commands>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum ListFormat {
+    Table,
+    Json,
+}
+
+impl ListFormat {
+    fn is_json(self) -> bool {
+        matches!(self, Self::Json)
+    }
 }
 
 #[derive(Subcommand)]
@@ -228,41 +235,50 @@ enum Commands {
     /// Opens an interactive model picker. Choose a cloud model from authenticated
     /// providers, download and activate local models, or add a custom local model.
     #[command(name = "model")]
-    Model,
+    Model {
+        #[command(subcommand)]
+        command: Option<ModelCommand>,
+    },
 
     /// View and browse transcription history
     ///
     /// Browse previous transcriptions, select one to copy to clipboard.
     /// Use arrow keys to navigate, Enter to copy, Esc to exit.
     #[command(visible_alias = "h")]
-    History,
+    History {
+        #[command(subcommand)]
+        command: Option<HistoryCommand>,
+    },
 
     /// Manage keywords for improved transcription accuracy
     ///
     /// Add technical terms, names, or domain-specific vocabulary to help
     /// the AI transcribe more accurately.
     #[command(visible_alias = "k")]
-    Keywords,
+    #[command(name = "keyword")]
+    Keyword {
+        #[command(subcommand)]
+        command: Option<KeywordCommand>,
+    },
 
     /// Open configuration file in your preferred editor
     ///
     /// Edit audio settings, provider options, and other configuration.
     /// Uses $EDITOR environment variable or falls back to nano/vim.
     #[command(visible_alias = "c")]
-    Config,
-
-    /// List available audio input devices
-    ///
-    /// Shows device IDs, names, and configurations to help configure
-    /// the correct input device in ostt.toml.
-    #[command(name = "list-devices")]
-    ListDevices,
+    Config {
+        #[command(subcommand)]
+        command: Option<ConfigCommand>,
+    },
 
     /// Show recent log entries from the application
     ///
     /// Display the last 50 lines of the most recent log file.
     /// Useful for troubleshooting issues.
-    Logs,
+    Logs {
+        #[command(subcommand)]
+        command: Option<LogsCommand>,
+    },
 
     /// Post-process a transcription from history
     ///
@@ -270,7 +286,7 @@ enum Commands {
     /// Shows the action picker if no action is specified.
     ///
     #[command(
-        after_help = "EXAMPLES:\n    ostt process                      Process most recent, show picker\n    ostt process clean                Process most recent with the clean action\n    ostt process 5                    Process #5, show picker\n    ostt process 5 clean -c           Process #5 with clean, copy to clipboard\n    ostt process --list               List configured actions"
+        after_help = "EXAMPLES:\n    ostt process                      Process most recent, show picker\n    ostt process clean                Process most recent with the clean action\n    ostt process 5                    Process #5, show picker\n    ostt process 5 clean -c           Process #5 with clean, copy to clipboard\n    ostt process list                 List configured actions"
     )]
     #[command(visible_alias = "p")]
     Process {
@@ -282,10 +298,6 @@ enum Commands {
         #[arg(value_name = "ACTION")]
         action: Option<String>,
 
-        /// List all configured actions and exit
-        #[arg(long)]
-        list: bool,
-
         /// Copy result to clipboard instead of stdout (shadows global -c)
         #[arg(short, long)]
         clipboard: bool,
@@ -293,6 +305,10 @@ enum Commands {
         /// Write result to file instead of stdout (shadows global -o)
         #[arg(short, long, value_name = "FILE")]
         output: Option<String>,
+
+        /// Output format for `ostt process list`
+        #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+        format: ListFormat,
     },
 
     /// Launch ostt in a popup terminal window
@@ -323,14 +339,13 @@ enum Commands {
     ///   ostt completions bash > ostt.bash
     ///   ostt completions zsh > _ostt
     ///   ostt completions fish > ostt.fish
-    ///   ostt completions bash --install
+    ///   ostt completions install bash
     Completions {
         /// The shell to generate completions for
         #[arg(value_enum)]
-        shell: Shell,
-        /// Install completions to the standard system directory
-        #[arg(long, short)]
-        install: bool,
+        shell: Option<Shell>,
+        #[command(subcommand)]
+        command: Option<CompletionsCommand>,
     },
 
     /// Manage the local model daemon
@@ -350,6 +365,118 @@ enum Commands {
     Daemon {
         #[command(subcommand)]
         command: DaemonCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum ModelCommand {
+    /// List available transcription models
+    List {
+        /// Filter by provider ID
+        #[arg(long)]
+        provider: Option<String>,
+        /// Show only downloaded local models
+        #[arg(long)]
+        installed: bool,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+        format: ListFormat,
+    },
+    /// Show the currently selected transcription model
+    Current,
+    /// Select the active transcription model
+    Select {
+        #[arg(value_name = "PROVIDER/MODEL")]
+        model: String,
+    },
+    /// Manage local transcription models
+    Local {
+        #[command(subcommand)]
+        command: LocalModelCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum LocalModelCommand {
+    /// Download a local model
+    Download {
+        #[arg(value_name = "MODEL_ID")]
+        model_id: String,
+    },
+    /// Remove a downloaded local model
+    Remove {
+        #[arg(value_name = "MODEL_ID")]
+        model_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum KeywordCommand {
+    /// List transcription keywords
+    List {
+        /// Output format
+        #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+        format: ListFormat,
+    },
+    /// Add transcription keywords
+    Add {
+        #[arg(value_name = "KEYWORD", required = true)]
+        keywords: Vec<String>,
+    },
+    /// Remove transcription keywords
+    Remove {
+        #[arg(value_name = "KEYWORD", required = true)]
+        keywords: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommand {
+    /// Print the config file path
+    Path,
+    /// List audio input devices for config selection
+    ListDevices,
+}
+
+#[derive(Subcommand)]
+enum LogsCommand {
+    /// Follow the latest log file
+    Follow,
+    /// Print the latest log file path
+    Path,
+}
+
+#[derive(Subcommand)]
+enum HistoryCommand {
+    /// List transcription history
+    List {
+        /// Limit to N most recent entries
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+        format: ListFormat,
+    },
+    /// Show a transcription from history
+    Show {
+        /// History index (1 = most recent)
+        #[arg(value_name = "N")]
+        index: Option<usize>,
+    },
+    /// Copy a transcription from history to clipboard
+    Copy {
+        /// History index (1 = most recent)
+        #[arg(value_name = "N")]
+        index: Option<usize>,
+    },
+}
+
+#[derive(Subcommand)]
+enum CompletionsCommand {
+    /// Install completions to the standard system directory
+    Install {
+        #[arg(value_enum)]
+        shell: Shell,
     },
 }
 
@@ -382,9 +509,23 @@ enum DaemonCommand {
 #[derive(Subcommand)]
 enum AuthCommand {
     /// Add or update a cloud provider credential
-    Login,
+    Login {
+        /// Provider ID to log in to
+        provider: Option<String>,
+    },
     /// Remove a cloud provider credential
-    Logout,
+    Logout {
+        /// Provider ID to log out from
+        provider: Option<String>,
+    },
+    /// List authenticated providers
+    List {
+        /// Output format
+        #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+        format: ListFormat,
+    },
+    /// Show authentication status
+    Status,
 }
 
 fn resolve_process_args(
@@ -438,32 +579,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
         return commands::daemon::handle_daemon_run(model_id.clone(), idle_timeout_secs).await;
     }
 
-    // Print logo only for plain-text informational commands where it adds context
-    // without interfering with TUI rendering or piped output.
-    let show_logo = matches!(
-        &cli.command,
-        Some(Commands::ListDevices) | Some(Commands::Logs) | Some(Commands::Auth { .. })
-    );
-    let show_logo = show_logo
-        || matches!(
-            &cli.command,
-            Some(Commands::Daemon {
-                command: DaemonCommand::Start
-                    | DaemonCommand::Stop
-                    | DaemonCommand::Restart
-                    | DaemonCommand::Status
-                    | DaemonCommand::Install
-                    | DaemonCommand::Uninstall,
-            })
-        );
-    if show_logo {
-        eprintln!("\n ┏┓┏╋╋ \n ┗┛┛┗┗\n");
-    }
-
     match &cli.command {
         Some(Commands::Completions {
-            shell,
-            install: true,
+            command: Some(CompletionsCommand::Install { shell }),
+            ..
         }) => {
             let dir = completion_dir(*shell);
             let filename = completion_filename(*shell);
@@ -481,22 +600,21 @@ pub async fn run() -> Result<(), anyhow::Error> {
             return Ok(());
         }
         Some(Commands::Completions {
-            shell,
-            install: false,
+            shell: Some(shell),
+            command: None,
         }) => {
             generate(*shell, &mut Cli::command(), "ostt", &mut io::stdout());
             return Ok(());
         }
-        Some(Commands::ListDevices) => {
-            return match commands::handle_list_devices() {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    process::exit(1);
-                }
-            };
+        Some(Commands::Completions {
+            shell: None,
+            command: None,
+        }) => {
+            return Err(anyhow!(
+                "Use 'ostt completions <SHELL>' or 'ostt completions install <SHELL>'."
+            ));
         }
-        Some(Commands::Logs) => {
+        Some(Commands::Logs { command: None }) => {
             return match commands::handle_logs() {
                 Ok(()) => Ok(()),
                 Err(e) => {
@@ -505,6 +623,12 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 }
             };
         }
+        Some(Commands::Logs {
+            command: Some(LogsCommand::Path),
+        }) => return commands::logs::handle_logs_path(),
+        Some(Commands::Logs {
+            command: Some(LogsCommand::Follow),
+        }) => return commands::logs::handle_logs_follow(),
         _ => {}
     }
 
@@ -587,9 +711,15 @@ pub async fn run() -> Result<(), anyhow::Error> {
             commands::handle_replay(index).await?;
         }
         Some(Commands::Auth { command }) => {
-            let result = match command.unwrap_or(AuthCommand::Login) {
-                AuthCommand::Login => commands::handle_auth().await,
-                AuthCommand::Logout => commands::auth::handle_logout(&config_data).await,
+            let result = match command.unwrap_or(AuthCommand::Login { provider: None }) {
+                AuthCommand::Login { provider } => {
+                    commands::auth::handle_auth_login(provider).await
+                }
+                AuthCommand::Logout { provider } => {
+                    commands::auth::handle_logout(&config_data, provider).await
+                }
+                AuthCommand::List { format } => commands::auth::handle_auth_list(format.is_json()),
+                AuthCommand::Status => commands::auth::handle_auth_status(),
             };
 
             if let Err(e) = result {
@@ -603,27 +733,68 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 }
             }
         }
-        Some(Commands::Model) => {
-            commands::handle_model().await?;
-        }
-        Some(Commands::History) => {
-            commands::handle_history().await?;
-        }
-        Some(Commands::Keywords) => {
-            commands::handle_keywords().await?;
-        }
-        Some(Commands::Config) => {
-            commands::handle_config()?;
+        Some(Commands::Model { command }) => match command {
+            None => commands::handle_model().await?,
+            Some(ModelCommand::List {
+                provider,
+                installed,
+                format,
+            }) => commands::model::handle_model_list(provider, installed, format.is_json()).await?,
+            Some(ModelCommand::Current) => commands::model::handle_model_current()?,
+            Some(ModelCommand::Select { model }) => {
+                commands::model::handle_model_select(model).await?
+            }
+            Some(ModelCommand::Local { command }) => match command {
+                LocalModelCommand::Download { model_id } => {
+                    commands::model::handle_model_local_download(model_id).await?
+                }
+                LocalModelCommand::Remove { model_id } => {
+                    commands::model::handle_model_local_remove(model_id).await?
+                }
+            },
+        },
+        Some(Commands::History { command }) => match command {
+            None => commands::handle_history().await?,
+            Some(HistoryCommand::List { limit, format }) => {
+                commands::history::handle_history_list(limit, format.is_json())?
+            }
+            Some(HistoryCommand::Show { index }) => commands::history::handle_history_show(index)?,
+            Some(HistoryCommand::Copy { index }) => commands::history::handle_history_copy(index)?,
+        },
+        Some(Commands::Keyword { command }) => match command {
+            None => commands::handle_keywords().await?,
+            Some(KeywordCommand::List { format }) => {
+                commands::keywords::handle_keyword_list(format.is_json())?
+            }
+            Some(KeywordCommand::Add { keywords }) => {
+                commands::keywords::handle_keyword_add(keywords)?
+            }
+            Some(KeywordCommand::Remove { keywords }) => {
+                commands::keywords::handle_keyword_remove(keywords)?
+            }
+        },
+        Some(Commands::Config { command }) => match command {
+            None => commands::handle_config()?,
+            Some(ConfigCommand::Path) => commands::config::handle_config_path()?,
+            Some(ConfigCommand::ListDevices) => commands::handle_list_devices()?,
+        },
+        Some(Commands::Process {
+            index_or_action,
+            action,
+            format,
+            ..
+        }) if index_or_action.as_deref() == Some("list") && action.is_none() => {
+            commands::process::handle_process_list(&config_data, format.is_json())?;
         }
         Some(Commands::Process {
             index_or_action,
             action,
-            list,
             clipboard,
             output,
+            ..
         }) => {
             let (index, action) = resolve_process_args(index_or_action, action)?;
-            commands::handle_process(&config_data, index, action, list, clipboard, output).await?;
+            commands::handle_process(&config_data, index, action, false, clipboard, output).await?;
         }
         Some(Commands::Launch { args }) => {
             // Reconstruct the full ostt args list. Global flags (-c, -o, -p) are
@@ -660,7 +831,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 unreachable!("daemon run is handled before logging init")
             }
         },
-        Some(Commands::Completions { .. }) | Some(Commands::ListDevices) | Some(Commands::Logs) => {
+        Some(Commands::Completions { .. }) | Some(Commands::Logs { .. }) => {
             unreachable!("These commands are handled earlier")
         }
     }
@@ -748,7 +919,68 @@ mod tests {
     fn cli_accepts_model_override_for_launch() {
         let cli = Cli::try_parse_from(["ostt", "launch", "-m", "deepgram/nova-3", "-c"])
             .expect("parse cli");
-        assert_eq!(cli.model.as_deref(), Some("deepgram/nova-3"));
-        assert!(cli.clipboard);
+        match cli.command {
+            Some(Commands::Launch { args }) => {
+                assert_eq!(args, ["-m", "deepgram/nova-3", "-c"]);
+            }
+            _ => panic!("expected launch command"),
+        }
+    }
+
+    #[test]
+    fn cli_uses_singular_keyword_command() {
+        assert!(Cli::try_parse_from(["ostt", "keywords"]).is_err());
+
+        let cli = Cli::try_parse_from(["ostt", "keyword", "list", "--format", "json"])
+            .expect("parse cli");
+        match cli.command {
+            Some(Commands::Keyword {
+                command: Some(KeywordCommand::List { format }),
+            }) => assert_eq!(format, ListFormat::Json),
+            _ => panic!("expected keyword list command"),
+        }
+    }
+
+    #[test]
+    fn cli_moves_device_listing_under_config() {
+        assert!(Cli::try_parse_from(["ostt", "list-devices"]).is_err());
+
+        let cli = Cli::try_parse_from(["ostt", "config", "list-devices"]).expect("parse cli");
+        match cli.command {
+            Some(Commands::Config {
+                command: Some(ConfigCommand::ListDevices),
+            }) => {}
+            _ => panic!("expected config list-devices command"),
+        }
+    }
+
+    #[test]
+    fn cli_uses_subcommands_for_process_and_completion_listing_actions() {
+        assert!(Cli::try_parse_from(["ostt", "process", "--list"]).is_err());
+        assert!(Cli::try_parse_from(["ostt", "completions", "bash", "--install"]).is_err());
+
+        let cli = Cli::try_parse_from(["ostt", "process", "list", "--format", "json"])
+            .expect("parse cli");
+        match cli.command {
+            Some(Commands::Process {
+                index_or_action,
+                format,
+                ..
+            }) => {
+                assert_eq!(index_or_action.as_deref(), Some("list"));
+                assert_eq!(format, ListFormat::Json);
+            }
+            _ => panic!("expected process list command"),
+        }
+
+        let cli =
+            Cli::try_parse_from(["ostt", "completions", "install", "bash"]).expect("parse cli");
+        match cli.command {
+            Some(Commands::Completions {
+                command: Some(CompletionsCommand::Install { shell }),
+                ..
+            }) => assert_eq!(shell, Shell::Bash),
+            _ => panic!("expected completions install command"),
+        }
     }
 }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -7,6 +7,10 @@ use std::collections::HashSet;
 
 /// Handles cloud provider API key management.
 pub async fn handle_auth() -> Result<(), anyhow::Error> {
+    handle_auth_login(None).await
+}
+
+pub async fn handle_auth_login(provider_id: Option<String>) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Authentication ===");
 
     ctrlc::set_handler(move || {}).expect("setting Ctrl-C handler");
@@ -18,7 +22,10 @@ pub async fn handle_auth() -> Result<(), anyhow::Error> {
         return Err(anyhow::anyhow!("No cloud providers available"));
     }
 
-    let selected_provider = select_provider("Select provider:", &providers)?;
+    let selected_provider = match provider_id {
+        Some(provider_id) => provider_by_id(&provider_id, &providers)?,
+        None => select_provider("Select provider:", &providers)?,
+    };
     let current_api_key = config::get_api_key(selected_provider.id()).ok().flatten();
 
     let api_key = if current_api_key.is_some() {
@@ -59,7 +66,10 @@ pub async fn handle_auth() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-pub async fn handle_logout(config_data: &config::OsttConfig) -> Result<(), anyhow::Error> {
+pub async fn handle_logout(
+    config_data: &config::OsttConfig,
+    provider_id: Option<String>,
+) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Logout ===");
 
     ctrlc::set_handler(move || {}).expect("setting Ctrl-C handler");
@@ -76,7 +86,10 @@ pub async fn handle_logout(config_data: &config::OsttConfig) -> Result<(), anyho
         return Ok(());
     }
 
-    let selected_provider = select_provider("Select provider to log out:", &providers)?;
+    let selected_provider = match provider_id {
+        Some(provider_id) => provider_by_id(&provider_id, &providers)?,
+        None => select_provider("Select provider to log out:", &providers)?,
+    };
     let confirmed = confirm(format!(
         "Remove stored credential for {}?",
         selected_provider.name()
@@ -104,6 +117,36 @@ pub async fn handle_logout(config_data: &config::OsttConfig) -> Result<(), anyho
     Ok(())
 }
 
+pub fn handle_auth_list(json: bool) -> Result<(), anyhow::Error> {
+    let provider_ids = config::get_authorized_providers()?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&provider_ids)?);
+        return Ok(());
+    }
+
+    if provider_ids.is_empty() {
+        println!("No cloud credentials found.");
+        return Ok(());
+    }
+
+    for provider_id in provider_ids {
+        println!("{provider_id}");
+    }
+
+    Ok(())
+}
+
+pub fn handle_auth_status() -> Result<(), anyhow::Error> {
+    let provider_ids = config::get_authorized_providers()?;
+    if provider_ids.is_empty() {
+        println!("No cloud credentials found.");
+    } else {
+        println!("Authenticated providers: {}", provider_ids.join(", "));
+    }
+    Ok(())
+}
+
 fn select_provider(
     prompt: &str,
     providers: &[transcription::TranscriptionProvider],
@@ -117,6 +160,17 @@ fn select_provider(
         .map_err(|e| anyhow::anyhow!("Selection cancelled: {e}"))?;
 
     Ok(providers[selected_idx].clone())
+}
+
+fn provider_by_id(
+    provider_id: &str,
+    providers: &[transcription::TranscriptionProvider],
+) -> Result<transcription::TranscriptionProvider, anyhow::Error> {
+    providers
+        .iter()
+        .find(|provider| provider.id() == provider_id)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("Unknown or unavailable provider: {provider_id}"))
 }
 
 fn cloud_providers() -> Vec<transcription::TranscriptionProvider> {

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -41,6 +41,11 @@ pub fn handle_config() -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn handle_config_path() -> anyhow::Result<()> {
+    println!("{}", crate::app_dirs::config_path()?.display());
+    Ok(())
+}
+
 /// Finds the best available editor to use.
 ///
 /// Tries in order: $EDITOR, nano, vi

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -38,3 +38,64 @@ pub async fn handle_history() -> Result<(), anyhow::Error> {
     tracing::debug!("History view closed");
     Ok(())
 }
+
+pub fn handle_history_list(limit: Option<usize>, json: bool) -> Result<(), anyhow::Error> {
+    let data_dir = crate::app_dirs::data_dir();
+    let mut history_manager = HistoryManager::new(&data_dir)?;
+    let mut entries = history_manager.get_all_transcriptions()?;
+    if let Some(limit) = limit {
+        entries.truncate(limit);
+    }
+
+    if json {
+        let rows: Vec<_> = entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| {
+                serde_json::json!({
+                    "index": index + 1,
+                    "id": entry.id,
+                    "created_at": entry.created_at.to_rfc3339(),
+                    "text": entry.text,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    for (index, entry) in entries.iter().enumerate() {
+        let preview = entry.text.lines().next().unwrap_or("");
+        println!(
+            "{}\t{}\t{}",
+            index + 1,
+            entry.created_at.format("%Y-%m-%d %H:%M"),
+            preview
+        );
+    }
+
+    Ok(())
+}
+
+pub fn handle_history_show(index: Option<usize>) -> Result<(), anyhow::Error> {
+    let data_dir = crate::app_dirs::data_dir();
+    let mut history_manager = HistoryManager::new(&data_dir)?;
+    let n = index.unwrap_or(1);
+    let entry = history_manager
+        .get_transcription_by_index(n)?
+        .ok_or_else(|| anyhow::anyhow!("No transcription found at index {n}."))?;
+    println!("{}", entry.text);
+    Ok(())
+}
+
+pub fn handle_history_copy(index: Option<usize>) -> Result<(), anyhow::Error> {
+    let data_dir = crate::app_dirs::data_dir();
+    let mut history_manager = HistoryManager::new(&data_dir)?;
+    let n = index.unwrap_or(1);
+    let entry = history_manager
+        .get_transcription_by_index(n)?
+        .ok_or_else(|| anyhow::anyhow!("No transcription found at index {n}."))?;
+    copy_to_clipboard(&entry.text)?;
+    println!("Copied transcription #{n} to clipboard.");
+    Ok(())
+}

--- a/src/commands/keywords.rs
+++ b/src/commands/keywords.rs
@@ -18,3 +18,42 @@ pub async fn handle_keywords() -> Result<()> {
 
     Ok(())
 }
+
+pub fn handle_keyword_list(json: bool) -> Result<()> {
+    let manager = KeywordsManager::new(&crate::app_dirs::config_dir())?;
+    let keywords = manager.load_keywords()?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&keywords)?);
+        return Ok(());
+    }
+
+    for keyword in keywords {
+        println!("{keyword}");
+    }
+
+    Ok(())
+}
+
+pub fn handle_keyword_add(keywords: Vec<String>) -> Result<()> {
+    let mut manager = KeywordsManager::new(&crate::app_dirs::config_dir())?;
+    for keyword in keywords {
+        manager.add_keyword(keyword)?;
+    }
+    Ok(())
+}
+
+pub fn handle_keyword_remove(keywords_to_remove: Vec<String>) -> Result<()> {
+    let manager = KeywordsManager::new(&crate::app_dirs::config_dir())?;
+    let mut keywords = manager.load_keywords()?;
+
+    for keyword in &keywords_to_remove {
+        let Some(index) = keywords.iter().position(|candidate| candidate == keyword) else {
+            anyhow::bail!("Keyword not found: {keyword}");
+        };
+        keywords.remove(index);
+    }
+
+    manager.save_keywords(&keywords)?;
+    Ok(())
+}

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -2,7 +2,10 @@
 
 use anyhow::anyhow;
 use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 const DEFAULT_LINES: usize = 50;
 
@@ -62,6 +65,38 @@ pub fn handle_logs() -> Result<(), anyhow::Error> {
     }
 
     Ok(())
+}
+
+pub fn handle_logs_path() -> Result<(), anyhow::Error> {
+    let log_dir = crate::app_dirs::log_dir()?;
+    let log_file = find_latest_log(&log_dir).unwrap_or_else(|_| log_dir.join("ostt.log"));
+    println!("{}", log_file.display());
+    Ok(())
+}
+
+pub fn handle_logs_follow() -> Result<(), anyhow::Error> {
+    let log_dir = crate::app_dirs::log_dir()?;
+    let log_file = find_latest_log(&log_dir)?;
+    let mut file = fs::File::open(&log_file)
+        .map_err(|e| anyhow!("Failed to open log file {}: {e}", log_file.display()))?;
+    let mut position = file.seek(SeekFrom::End(0))?;
+
+    loop {
+        thread::sleep(Duration::from_millis(500));
+        let len = file.metadata()?.len();
+        if len < position {
+            position = file.seek(SeekFrom::Start(0))?;
+        }
+        if len == position {
+            continue;
+        }
+
+        file.seek(SeekFrom::Start(position))?;
+        let mut buffer = String::new();
+        file.read_to_string(&mut buffer)?;
+        print!("{buffer}");
+        position = file.stream_position()?;
+    }
 }
 
 /// Finds the latest (most recently modified) log file in the directory.

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1,5 +1,229 @@
 use crate::model::ModelView;
+use crate::transcription::local_models;
+use crate::transcription::{self, TranscriptionProvider};
+use std::io::Write;
 
 pub async fn handle_model() -> anyhow::Result<()> {
     ModelView::new()?.run().await
+}
+
+pub async fn handle_model_list(
+    provider: Option<String>,
+    installed: bool,
+    json: bool,
+) -> anyhow::Result<()> {
+    if let Some(provider_id) = provider.as_deref() {
+        if TranscriptionProvider::from_id(provider_id).is_none() {
+            anyhow::bail!(
+                "Unknown provider '{}'. Supported providers: {}.",
+                provider_id,
+                TranscriptionProvider::supported_ids().join(", ")
+            );
+        }
+    }
+
+    let selected = crate::config::get_selected_model_entry()?;
+    let mut rows = Vec::new();
+
+    if !installed {
+        for model in transcription::all_models() {
+            if provider
+                .as_deref()
+                .is_some_and(|id| id != model.provider_id)
+            {
+                continue;
+            }
+            rows.push(ModelListRow {
+                provider: model.provider_id.to_string(),
+                model: model.model_id.to_string(),
+                name: model.display_name.to_string(),
+                installed: None,
+                active: selected.as_ref().is_some_and(|selected| {
+                    selected.provider_id == model.provider_id && selected.model_id == model.model_id
+                }),
+            });
+        }
+    }
+
+    if provider.as_deref().is_none_or(|id| id == "local") {
+        let state = local_models::load_state();
+        let registry = local_models::fetch_registry().await.unwrap_or_default();
+        for entry in registry.iter().chain(state.custom_models.iter()) {
+            let is_installed = local_models::model_destination(entry).exists();
+            if installed && !is_installed {
+                continue;
+            }
+            rows.push(ModelListRow {
+                provider: "local".to_string(),
+                model: entry.id.clone(),
+                name: entry.name.clone(),
+                installed: Some(is_installed),
+                active: selected.as_ref().is_some_and(|selected| {
+                    selected.provider_id == "local" && selected.model_id == entry.id
+                }),
+            });
+        }
+    }
+
+    if json {
+        let rows: Vec<_> = rows
+            .iter()
+            .map(|row| {
+                serde_json::json!({
+                    "provider": row.provider,
+                    "model": row.model,
+                    "name": row.name,
+                    "installed": row.installed,
+                    "active": row.active,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    for row in rows {
+        let active = if row.active { " *" } else { "" };
+        let installed = match row.installed {
+            Some(true) => " [installed]",
+            Some(false) => "",
+            None => "",
+        };
+        println!(
+            "{}/{}\t{}{}{}",
+            row.provider, row.model, row.name, installed, active
+        );
+    }
+
+    Ok(())
+}
+
+pub fn handle_model_current() -> anyhow::Result<()> {
+    match crate::config::get_selected_model_entry()? {
+        Some(selected) => println!("{}/{}", selected.provider_id, selected.model_id),
+        None => println!("No model selected."),
+    }
+    Ok(())
+}
+
+pub async fn handle_model_select(model: String) -> anyhow::Result<()> {
+    let selected = crate::config::parse_provider_model(&model)?;
+    if selected.provider_id == "local" {
+        local_models::activate_model(&selected.model_id)?;
+        reload_daemon_if_running(&selected.model_id).await?;
+        println!("Selected local model: local/{}", selected.model_id);
+        return Ok(());
+    }
+
+    if crate::config::get_api_key(&selected.provider_id)?.is_none() {
+        anyhow::bail!(
+            "No credential found for provider '{}'. Run 'ostt auth login' first.",
+            selected.provider_id
+        );
+    }
+
+    crate::config::save_selected_model(&selected.provider_id, &selected.model_id)?;
+    println!(
+        "Selected model: {}/{}",
+        selected.provider_id, selected.model_id
+    );
+    Ok(())
+}
+
+pub async fn handle_model_local_download(model_id: String) -> anyhow::Result<()> {
+    let entry = find_local_model_entry(&model_id).await?;
+    let destination = local_models::model_destination(&entry);
+    if destination.exists() {
+        println!("Local model already downloaded: local/{model_id}");
+        return Ok(());
+    }
+
+    eprintln!("Downloading local model: local/{model_id}");
+    local_models::download_model(
+        &entry.url,
+        &destination,
+        Some(Box::new(|downloaded_bytes, total_bytes, speed_mbps| {
+            print_download_progress(downloaded_bytes, total_bytes, speed_mbps);
+        })),
+    )
+    .await?;
+    eprintln!();
+    local_models::validate_downloaded_model(&entry)?;
+    local_models::mark_downloaded_registry_model(&entry)?;
+    println!("Downloaded local model: local/{model_id}");
+    Ok(())
+}
+
+pub async fn handle_model_local_remove(model_id: String) -> anyhow::Result<()> {
+    let loaded_model_id = crate::transcription::daemon_client::probe_daemon()
+        .await
+        .map(|info| info.model_id);
+    local_models::delete_model(&model_id)?;
+    if loaded_model_id.as_deref() == Some(model_id.as_str()) {
+        crate::transcription::daemon_client::shutdown_daemon().await?;
+    }
+    println!("Removed local model: local/{model_id}");
+    Ok(())
+}
+
+struct ModelListRow {
+    provider: String,
+    model: String,
+    name: String,
+    installed: Option<bool>,
+    active: bool,
+}
+
+async fn find_local_model_entry(model_id: &str) -> anyhow::Result<local_models::RegistryEntry> {
+    let state = local_models::load_state();
+    if let Some(entry) = state
+        .custom_models
+        .iter()
+        .find(|entry| entry.id == model_id)
+        .cloned()
+    {
+        return Ok(entry);
+    }
+
+    let registry = local_models::fetch_registry().await?;
+    registry
+        .into_iter()
+        .find(|entry| entry.id == model_id)
+        .ok_or_else(|| anyhow::anyhow!("Unknown local model: local/{model_id}"))
+}
+
+async fn reload_daemon_if_running(model_id: &str) -> anyhow::Result<()> {
+    let Some(info) = crate::transcription::daemon_client::probe_daemon().await else {
+        return Ok(());
+    };
+    if info.model_id != model_id {
+        crate::transcription::daemon_client::ensure_daemon(model_id, None).await?;
+    }
+    Ok(())
+}
+
+fn print_download_progress(downloaded_bytes: u64, total_bytes: u64, speed_mbps: f64) {
+    if total_bytes > 0 {
+        let percent = (downloaded_bytes as f64 / total_bytes as f64 * 100.0).clamp(0.0, 100.0);
+        eprint!(
+            "\r{percent:>5.1}%  {} / {}  {speed_mbps:.1} MB/s",
+            format_bytes(downloaded_bytes),
+            format_bytes(total_bytes),
+        );
+    } else {
+        eprint!(
+            "\r{} downloaded  {speed_mbps:.1} MB/s",
+            format_bytes(downloaded_bytes),
+        );
+    }
+    let _ = std::io::stderr().flush();
+}
+
+fn format_bytes(bytes: u64) -> String {
+    let mb = bytes as f64 / (1024.0 * 1024.0);
+    if mb >= 1024.0 {
+        format!("{:.1} GB", mb / 1024.0)
+    } else {
+        format!("{mb:.0} MB")
+    }
 }

--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -64,7 +64,7 @@ pub async fn handle_process(
             .get_action(id)
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "Unknown action '{id}'. Use 'ostt process --list' to see available actions."
+                    "Unknown action '{id}'. Use 'ostt process list' to see available actions."
                 )
             })?
             .clone();
@@ -110,5 +110,38 @@ pub async fn handle_process(
     output::write_text(&result, output_file, clipboard, "Processed result")?;
 
     tracing::info!("=== ostt Process Command Completed ===");
+    Ok(())
+}
+
+pub fn handle_process_list(
+    config_data: &config::OsttConfig,
+    json: bool,
+) -> Result<(), anyhow::Error> {
+    if config_data.process.actions.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No process actions configured. Add actions to ~/.config/ostt/ostt.toml"
+        ));
+    }
+
+    if json {
+        let actions: Vec<_> = config_data
+            .process
+            .actions
+            .iter()
+            .map(|action| {
+                serde_json::json!({
+                    "id": action.id,
+                    "name": action.name,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&actions)?);
+        return Ok(());
+    }
+
+    for action in &config_data.process.actions {
+        println!("{} — {}", action.id, action.name);
+    }
+
     Ok(())
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -37,8 +37,8 @@ impl std::fmt::Display for VisualizationType {
 pub struct AudioConfig {
     /// Audio device to use. Options:
     /// - "default" for system default device
-    /// - numeric index (0, 1, 2, etc.) from `ostt list-devices`
-    /// - device name from `ostt list-devices`
+    /// - numeric index (0, 1, 2, etc.) from `ostt config list-devices`
+    /// - device name from `ostt config list-devices`
     pub device: String,
     /// Peak volume threshold for visual indicator (0-100, percentage of reference level)
     #[serde(default = "default_peak_volume_threshold")]

--- a/src/process/execute.rs
+++ b/src/process/execute.rs
@@ -134,7 +134,7 @@ fn find_action(process_config: &ProcessConfig, action_id: &str) -> anyhow::Resul
         .cloned()
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Unknown action '{action_id}'. Use 'ostt process --list' to see available actions."
+                "Unknown action '{action_id}'. Use 'ostt process list' to see available actions."
             )
         })
 }

--- a/src/recording/audio.rs
+++ b/src/recording/audio.rs
@@ -397,7 +397,7 @@ fn find_device_by_name(host: &cpal::Host, device_spec: &str) -> Result<cpal::Dev
     }
 
     Err(anyhow!(
-        "Audio input device '{device_spec}' not found. Use 'ostt list-devices' to see available devices."
+        "Audio input device '{device_spec}' not found. Use 'ostt config list-devices' to see available devices."
     ))
 }
 

--- a/src/ui/components/app_layout.rs
+++ b/src/ui/components/app_layout.rs
@@ -12,7 +12,7 @@ pub struct AppLayout {
 }
 
 pub fn render_app_layout(frame: &mut Frame<'_>, area: Rect) -> AppLayout {
-    let padding_block = Block::default().padding(Padding::new(1, 1, 1, 0));
+    let padding_block = Block::default().padding(Padding::new(0, 0, 1, 0));
     frame.render_widget(&padding_block, area);
     let padded_area = padding_block.inner(area);
 


### PR DESCRIPTION
## Summary

Refines the OSTT CLI around a cleaner noun/action structure while keeping the bare resource commands interactive where that is the existing UX. This intentionally introduces breaking command syntax changes instead of maintaining deprecated aliases, because the application is still early and the goal is a clean long-term CLI surface.

## CLI structure changes

- Replaces `ostt keywords` with singular `ostt keyword`.
- Adds scriptable keyword actions: `ostt keyword list`, `ostt keyword add <KEYWORD>...`, and `ostt keyword remove <KEYWORD>...`.
- Replaces `ostt list-devices` with `ostt config list-devices` because device listing is primarily a config helper.
- Adds `ostt config path`.
- Adds scriptable model actions: `ostt model list`, `ostt model current`, and `ostt model select <PROVIDER/MODEL>`.
- Adds local model actions under `ostt model local`: `download <MODEL_ID>` and `remove <MODEL_ID>`.
- Adds stderr download progress for `ostt model local download`, keeping the final success message on stdout.
- Replaces `ostt process --list` with `ostt process list` while preserving the existing positional process execution forms.
- Replaces `ostt completions <SHELL> --install` with `ostt completions install <SHELL>`.
- Adds scriptable helpers for `auth list/status`, `history list/show/copy`, and `logs follow/path`.

## Help and UX cleanup

- Removes record-oriented options from unrelated management command help by scoping the root `-c/-o/-p/-m` flags away from subcommands that do not use them.
- Keeps model override available for transcription flows: `ostt -m`, `ostt record -m`, `ostt transcribe -m`, `ostt retry -m`, and `ostt launch -m`.
- Keeps `ostt` as shorthand for recording.
- Removes shared horizontal padding from TUI views that use the common app layout, leaving the recording animation view untouched.

## Documentation

- Updates README examples and common command references.
- Updates CHANGELOG with the new scriptable CLI actions and breaking command syntax changes.
- Updates user-facing recovery messages for process action listing and device listing.

## Verification

- Ran `cargo fmt`.
- Ran `cargo test` successfully: 138 tests passing.
- Checked help output for root, `model`, `keyword`, `config`, `auth`, `history`, `daemon`, `process`, and `completions`.
- Confirmed removed command forms fail: `ostt keywords`, `ostt list-devices`, `ostt process --list`, and `ostt completions bash --install`.