### PR TITLE
Add model-scoped transcription options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scriptable CLI actions for models, keywords, auth, history, config helpers, logs, and local model download/removal.
 - Added per-run model option overrides with repeatable `--mo key=value`, validated against the selected provider/model option schema for supported transcription providers.
 - Added `ostt model options [PROVIDER/MODEL] --format table|json` to list supported model option keys for scripting.
+- Added per-model local Whisper options under `[model_options."local/<model>"]`, using the same keys as `[providers.local]`.
 - Added OpenAI `gpt-4o-transcribe-diarize` and validated JSON-safe OpenAI transcription options for logprobs, Whisper timestamp metadata, and diarization requests.
 - Added validated JSON-safe Groq transcription options for `response_format` and `timestamp_granularities` based on Groq's speech-to-text documentation.
 - Added more DeepInfra speech-recognition models and validated DeepInfra-native options including `initial_prompt`, `task`, `chunk_level`, and `chunk_length_s`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 0.0.16 - 2026-06-01
-
 ### Added
 
-- Added per-run transcription model selection with `-m, --model <PROVIDER/MODEL>` for `ostt`, `ostt record`, `ostt transcribe`, `ostt retry`, and `ostt launch`. The override applies only to the current invocation and does not change the saved default model.
-- Added scriptable CLI actions for models, keywords, auth, history, config helpers, logs, and local model download/removal.
 - Added per-run model option overrides with repeatable `--mo key=value`, validated against the selected provider/model option schema for supported transcription providers.
 - Added `ostt model options [PROVIDER/MODEL] --format table|json` to list supported model option keys for scripting.
 - Added per-model local Whisper options under `[model_options."local/<model>"]`, using the same keys as `[providers.local]`.
@@ -25,16 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Cloud transcription models now use provider/model identities such as `deepgram/nova-3`, `deepinfra/openai/whisper-large-v3`, and `berget/KBLab/kb-whisper-large`, replacing older OSTT-invented model IDs.
 - Transcription request options are now model-scoped under `[model_options."provider/model"]` instead of provider-scoped settings under `[providers.*]`.
-- Local model UI and error messages now show full public IDs such as `local/turbo`.
 - `openai/gpt-4o-transcribe` now honors `--mo prompt=...` and saved `ostt keyword` terms as prompt context.
-- Cleaned up command syntax: `ostt keyword` replaces `ostt keywords`, `ostt config list-devices` replaces `ostt list-devices`, `ostt process list` replaces `ostt process --list`, and `ostt completions install <shell>` replaces `ostt completions <shell> --install`.
-- Record-only options no longer appear in unrelated management command help.
 
 ### Removed
 
 - Removed the misleading `audio.sample_rate` configuration setting. Recording now uses the input device sample rate, while local transcription compatibility is controlled by `audio.output_format = "pcm_s16le -ar 16000"`.
+
+## 0.0.16 - 2026-06-01
+
+### Added
+
+- Added per-run transcription model selection with `-m, --model <PROVIDER/MODEL>` for `ostt`, `ostt record`, `ostt transcribe`, `ostt retry`, and `ostt launch`. The override applies only to the current invocation and does not change the saved default model.
+- Added scriptable CLI actions for models, keywords, auth, history, config helpers, logs, and local model download/removal.
+
+### Changed
+
+- Cloud transcription models now use provider/model identities such as `deepgram/nova-3`, `deepinfra/openai/whisper-large-v3`, and `berget/KBLab/kb-whisper-large`, replacing older OSTT-invented model IDs.
+- Local model UI and error messages now show full public IDs such as `local/turbo`.
+- Cleaned up command syntax: `ostt keyword` replaces `ostt keywords`, `ostt config list-devices` replaces `ostt list-devices`, `ostt process list` replaces `ostt process --list`, and `ostt completions install <shell>` replaces `ostt completions <shell> --install`.
+- Record-only options no longer appear in unrelated management command help.
 
 ## 0.0.15 - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cloud transcription models now use provider/model identities such as `deepgram/nova-3`, `deepinfra/openai/whisper-large-v3`, and `berget/KBLab/kb-whisper-large`, replacing older OSTT-invented model IDs.
 - Transcription request options are now model-scoped under `[model_options."provider/model"]` instead of provider-scoped settings under `[providers.*]`.
 - Local model UI and error messages now show full public IDs such as `local/turbo`.
+- `openai/gpt-4o-transcribe` now honors `--mo prompt=...` and saved `ostt keyword` terms as prompt context.
 - Cleaned up command syntax: `ostt keyword` replaces `ostt keywords`, `ostt config list-devices` replaces `ostt list-devices`, `ostt process list` replaces `ostt process --list`, and `ostt completions install <shell>` replaces `ostt completions <shell> --install`.
 - Record-only options no longer appear in unrelated management command help.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added per-run transcription model selection with `-m, --model <PROVIDER/MODEL>` for `ostt`, `ostt record`, `ostt transcribe`, `ostt retry`, and `ostt launch`. The override applies only to the current invocation and does not change the saved default model.
 - Added scriptable CLI actions for models, keywords, auth, history, config helpers, logs, and local model download/removal.
+- Added per-run model option overrides with repeatable `--mo key=value`, validated against the selected provider/model option schema for supported transcription providers.
+- Added `ostt model options [PROVIDER/MODEL] --format table|json` to list supported model option keys for scripting.
+- Added OpenAI `gpt-4o-transcribe-diarize` and validated JSON-safe OpenAI transcription options for logprobs, Whisper timestamp metadata, and diarization requests.
+- Added validated JSON-safe Groq transcription options for `response_format` and `timestamp_granularities` based on Groq's speech-to-text documentation.
+- Added more DeepInfra speech-recognition models and validated DeepInfra-native options including `initial_prompt`, `task`, `chunk_level`, and `chunk_length_s`.
+- Added validated Berget transcription options for JSON-safe response format, word alignment, diarization, speaker embeddings, chunk size, and batch size.
+- Added validated ElevenLabs Scribe options for timestamps, file format, entity detection/redaction, diarization rules, and speaker-role detection rules.
+- Added validated Mistral Voxtral transcription options for `language`, `temperature`, `timestamp_granularities`, `diarize`, and `context_bias`.
 
 ### Changed
 
 - Cloud transcription models now use provider/model identities such as `deepgram/nova-3`, `deepinfra/openai/whisper-large-v3`, and `berget/KBLab/kb-whisper-large`, replacing older OSTT-invented model IDs.
+- Transcription request options are now model-scoped under `[model_options."provider/model"]` instead of provider-scoped settings under `[providers.*]`.
 - Local model UI and error messages now show full public IDs such as `local/turbo`.
 - Cleaned up command syntax: `ostt keyword` replaces `ostt keywords`, `ostt config list-devices` replaces `ostt list-devices`, `ostt process list` replaces `ostt process --list`, and `ostt completions install <shell>` replaces `ostt completions <shell> --install`.
 - Record-only options no longer appear in unrelated management command help.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ OSTT is built for people who treat the terminal as a normal place for voice inpu
 
 - **Linux-first voice input** - Global hotkey setup for Omarchy/Hyprland, GNOME, KDE, and other Linux desktops, with macOS support too.
 - **Provider choice** - Bring your own API key and switch between OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, ElevenLabs, Mistral, and local Whisper-compatible models.
+- **Model-scoped options** - Tune supported provider/model request options persistently or per run with `--mo key=value`.
 - **Local transcription models** - Download curated local models or add custom Hugging Face/direct model files for offline transcription.
 - **Terminal-native workflow** - Use stdout, clipboard, files, aliases, shell completions, logs, and pipes.
 - **Scriptable post-processing** - Transform transcripts with AI prompts or bash commands using `ostt -p` and `ostt process`.
@@ -78,6 +79,7 @@ ostt model          # Choose cloud or local transcription model
 ostt                # Record, transcribe, print to stdout
 ostt -c             # Record, transcribe, copy to clipboard
 ostt -m deepgram/nova-3 -c
+ostt -m local/turbo --mo language=sv -c
 ostt launch -c      # Popup workflow for global hotkeys
 ```
 
@@ -105,11 +107,13 @@ ostt                         # Record audio, print transcription
 ostt -c                      # Record audio, copy transcription
 ostt -o notes.txt            # Record audio, write transcription to file
 ostt -m openai/whisper-1     # Override model for this run
+ostt --mo language=sv -c     # Override a model option for this run
 ostt launch -c               # Open popup recorder
 ostt transcribe file.mp3 -m deepinfra/openai/whisper-large-v3
 ostt retry 2 -m groq/whisper-large-v3 -c
 ostt replay                  # Play most recent recording
 ostt model                   # Choose cloud or local transcription model
+ostt model options local/turbo   # List supported options for a model
 ostt history                 # Browse transcription history
 ostt keyword                 # Manage transcription keywords
 ostt config                  # Open config file
@@ -130,6 +134,8 @@ OSTT is bring-your-own-API-key and currently supports OpenAI, Deepgram, DeepInfr
 Run `ostt auth` to select your provider/model and save credentials securely.
 
 Run `ostt model` to switch between authenticated cloud models and local models. The local model screen can download curated models, activate downloaded models, delete local model files, and add custom models from Hugging Face model pages or direct `.gguf` / `ggml-*.bin` URLs.
+
+Per-model options are configured under `[model_options."provider/model"]` or passed per run with `--mo key=value`. See [Providers and Models](https://ostt.ai/reference/providers) and [Configuration](https://ostt.ai/guide/configuration) for supported options.
 
 ## Platform Setup
 

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -39,3 +39,15 @@ reference_level_db = -20
 #
 # Add more formats as needed - ffmpeg handles the rest!
 output_format = "mp3 -ab 16k -ar 12000"
+
+# Per-model transcription request options.
+# Keys must use the full provider/model id and options are validated against that model.
+#
+# Examples:
+# [model_options."deepgram/nova-3"]
+# detect_language = true
+# smart_format = true
+# keyterm = ["OSTT"]
+#
+# [model_options."berget/openai/whisper-large-v3"]
+# language = "sv"

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -51,3 +51,12 @@ output_format = "mp3 -ab 16k -ar 12000"
 #
 # [model_options."berget/openai/whisper-large-v3"]
 # language = "sv"
+#
+# Local Whisper-compatible models support the same option keys per model.
+# [model_options."local/turbo"]
+# language = "auto"
+# no_timestamps = true
+# no_context = true
+# temperature = 0.0
+# entropy_thold = 2.4
+# no_speech_thold = 0.6

--- a/src/app.rs
+++ b/src/app.rs
@@ -110,6 +110,10 @@ struct Cli {
     #[arg(short = 'm', long = "model", value_name = "PROVIDER/MODEL")]
     model: Option<String>,
 
+    /// Override a model option for this run, as key=value
+    #[arg(long = "mo", value_name = "KEY=VALUE", global = true)]
+    model_options: Vec<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -384,6 +388,15 @@ enum ModelCommand {
     },
     /// Show the currently selected transcription model
     Current,
+    /// List supported model options for a transcription model
+    Options {
+        /// Model to inspect. Defaults to the currently selected model.
+        #[arg(value_name = "PROVIDER/MODEL")]
+        model: Option<String>,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+        format: ListFormat,
+    },
     /// Select the active transcription model
     Select {
         #[arg(value_name = "PROVIDER/MODEL")]
@@ -660,8 +673,15 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 .as_deref()
                 .map(crate::config::parse_provider_model)
                 .transpose()?;
-            commands::handle_record(&config_data, clipboard, output, process, model_override)
-                .await?;
+            commands::handle_record(
+                &config_data,
+                clipboard,
+                output,
+                process,
+                model_override,
+                &cli.model_options,
+            )
+            .await?;
         }
         Some(Commands::Retry {
             index,
@@ -682,6 +702,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 output,
                 process,
                 model_override,
+                &cli.model_options,
             )
             .await?;
         }
@@ -704,6 +725,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 output,
                 process,
                 model_override,
+                &cli.model_options,
             )
             .await?;
         }
@@ -741,6 +763,9 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 format,
             }) => commands::model::handle_model_list(provider, installed, format.is_json()).await?,
             Some(ModelCommand::Current) => commands::model::handle_model_current()?,
+            Some(ModelCommand::Options { model, format }) => {
+                commands::model::handle_model_options(model, format.is_json())?
+            }
             Some(ModelCommand::Select { model }) => {
                 commands::model::handle_model_select(model).await?
             }
@@ -817,6 +842,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
             if let Some(ref model) = cli.model {
                 full_args.insert(0, model.clone());
                 full_args.insert(0, "-m".to_string());
+            }
+            for model_option in cli.model_options.iter().rev() {
+                full_args.insert(0, model_option.clone());
+                full_args.insert(0, "--mo".to_string());
             }
             commands::handle_launch(&config_data, full_args).await?;
         }
@@ -928,6 +957,33 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_model_options_listing_format() {
+        let cli = Cli::try_parse_from([
+            "ostt",
+            "model",
+            "options",
+            "openai/gpt-4o-transcribe",
+            "--format",
+            "json",
+        ])
+        .expect("parse cli");
+
+        match cli.command {
+            Some(Commands::Model {
+                command:
+                    Some(ModelCommand::Options {
+                        model: Some(model),
+                        format,
+                    }),
+            }) => {
+                assert_eq!(model, "openai/gpt-4o-transcribe");
+                assert_eq!(format, ListFormat::Json);
+            }
+            _ => panic!("expected model options command"),
+        }
+    }
+
+    #[test]
     fn cli_uses_singular_keyword_command() {
         assert!(Cli::try_parse_from(["ostt", "keywords"]).is_err());
 
@@ -982,5 +1038,66 @@ mod tests {
             }) => assert_eq!(shell, Shell::Bash),
             _ => panic!("expected completions install command"),
         }
+    }
+
+    #[test]
+    fn cli_accepts_repeatable_model_options_for_default_record() {
+        let cli = Cli::try_parse_from([
+            "ostt",
+            "--mo",
+            "detect_language=false",
+            "--mo",
+            "smart_format=true",
+        ])
+        .expect("parse cli");
+
+        assert_eq!(
+            cli.model_options,
+            vec!["detect_language=false", "smart_format=true"]
+        );
+    }
+
+    #[test]
+    fn cli_accepts_model_options_for_transcribe() {
+        let cli = Cli::try_parse_from(["ostt", "transcribe", "audio.ogg", "--mo", "language=sv"])
+            .expect("parse cli");
+
+        assert_eq!(cli.model_options, vec!["language=sv"]);
+        match cli.command {
+            Some(Commands::Transcribe { .. }) => {}
+            _ => panic!("expected transcribe command"),
+        }
+    }
+
+    #[test]
+    fn cli_collects_model_options_once_for_subcommands() {
+        let cli = Cli::try_parse_from([
+            "ostt",
+            "transcribe",
+            "audio.ogg",
+            "--mo",
+            "diarize=true",
+            "--mo",
+            "language=sv",
+        ])
+        .expect("parse cli");
+
+        assert_eq!(cli.model_options, vec!["diarize=true", "language=sv"]);
+    }
+
+    #[test]
+    fn cli_accepts_model_options_for_launch() {
+        let cli =
+            Cli::try_parse_from(["ostt", "launch", "--mo", "language=sv"]).expect("parse cli");
+
+        assert_eq!(cli.model_options, vec!["language=sv"]);
+    }
+
+    #[test]
+    fn cli_accepts_global_model_options_before_subcommand() {
+        let cli = Cli::try_parse_from(["ostt", "--mo", "language=sv", "transcribe", "audio.ogg"])
+            .expect("parse cli");
+
+        assert_eq!(cli.model_options, vec!["language=sv"]);
     }
 }

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -106,6 +106,46 @@ pub fn handle_model_current() -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn handle_model_options(model: Option<String>, json: bool) -> anyhow::Result<()> {
+    let selected = match model {
+        Some(model) => crate::config::parse_provider_model(&model)?,
+        None => crate::config::get_selected_model_entry()?.ok_or_else(|| {
+            anyhow::anyhow!("No model selected. Pass PROVIDER/MODEL or run 'ostt model' first.")
+        })?,
+    };
+    let full_model_id = format!("{}/{}", selected.provider_id, selected.model_id);
+    let schema = transcription::api::option_schema(&selected.provider_id, &selected.model_id)
+        .ok_or_else(|| anyhow::anyhow!("No model options are supported for {full_model_id}."))?;
+
+    if json {
+        let options: Vec<_> = schema
+            .options()
+            .iter()
+            .map(|option| {
+                serde_json::json!({
+                    "name": option.name,
+                    "type": option.kind.name(),
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "provider": selected.provider_id,
+                "model": selected.model_id,
+                "options": options,
+            }))?
+        );
+        return Ok(());
+    }
+
+    for option in schema.options() {
+        println!("{}: {}", option.name, option.kind.name());
+    }
+
+    Ok(())
+}
+
 pub async fn handle_model_select(model: String) -> anyhow::Result<()> {
     let selected = crate::config::parse_provider_model(&model)?;
     if selected.provider_id == "local" {

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -30,6 +30,7 @@ pub async fn handle_record(
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<SelectedModel>,
+    model_option_overrides: &[String],
 ) -> anyhow::Result<()> {
     tracing::info!("=== ostt Audio Recorder Started ===");
     tracing::info!(
@@ -74,8 +75,9 @@ pub async fn handle_record(
     // Prune only after a real recording was saved so cancellation cannot mutate history.
     recording_history::prune_old_recordings();
 
-    let transcription_context = crate::transcription::build_context(config, model_override)
-        .context("failed to build transcription context")?;
+    let transcription_context =
+        crate::transcription::build_context(config, model_override, model_option_overrides)
+            .context("failed to build transcription context")?;
     let model_id = transcription_context.selected_model.model_id.clone();
     let filepath_str = filepath.to_string_lossy().to_string();
 

--- a/src/commands/retry.rs
+++ b/src/commands/retry.rs
@@ -22,6 +22,7 @@ pub async fn handle_retry(
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<config::SelectedModel>,
+    model_option_overrides: &[String],
 ) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Retry Command ===");
 
@@ -51,7 +52,8 @@ pub async fn handle_retry(
 
     tracing::info!("Retrying transcription for recording #{}", index);
 
-    let context = transcription::build_context(config_data, model_override)?;
+    let context =
+        transcription::build_context(config_data, model_override, model_option_overrides)?;
 
     // Transcribe
     tracing::debug!("Starting transcription for retry...");

--- a/src/commands/transcribe.rs
+++ b/src/commands/transcribe.rs
@@ -25,6 +25,7 @@ pub async fn handle_transcribe(
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<config::SelectedModel>,
+    model_option_overrides: &[String],
 ) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Transcribe Command ===");
 
@@ -35,7 +36,8 @@ pub async fn handle_transcribe(
 
     tracing::info!("Transcribing file: {}", file.display());
 
-    let context = transcription::build_context(config_data, model_override)?;
+    let context =
+        transcription::build_context(config_data, model_override, model_option_overrides)?;
 
     // Transcribe
     tracing::debug!("Starting transcription...");

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -638,6 +638,14 @@ pub fn validate_model_options(model_options: &ModelOptionsConfig) -> anyhow::Res
             );
         }
 
+        if provider_id == "local" && !crate::transcription::local_models::is_safe_model_id(model_id)
+        {
+            anyhow::bail!(
+                "Invalid model_options key '{}'. Local model id must contain only lowercase letters, digits, '.', '_' or '-'.",
+                full_model_id
+            );
+        }
+
         let schema = api::option_schema(provider_id, model_id).ok_or_else(|| {
             anyhow::anyhow!(
                 "Invalid model_options key '{}'. No options are supported for this model.",
@@ -718,7 +726,24 @@ fn validate_model_option_type(
         );
     }
 
+    if matches_empty_string(expected, value) {
+        anyhow::bail!(
+            "Invalid value for option '{}' in '{}'. Value must not be empty.",
+            option_name,
+            full_model_id,
+        );
+    }
+
     Ok(())
+}
+
+fn matches_empty_string(expected: model::ModelOptionKind, value: &ModelOptionValue) -> bool {
+    match (expected, value) {
+        (model::ModelOptionKind::String, ModelOptionValue::String(s))
+        | (model::ModelOptionKind::BoolOrString, ModelOptionValue::String(s)) => s.is_empty(),
+        (model::ModelOptionKind::StringOrStringList, ModelOptionValue::String(s)) => s.is_empty(),
+        _ => false,
+    }
 }
 
 pub fn ensure_local_transcription_audio_config() -> anyhow::Result<()> {
@@ -1621,6 +1646,38 @@ model = "whisper-1"
         let config = parse_ostt_config(toml_str).unwrap();
         let err = validate_ostt_config(&config).unwrap_err().to_string();
         assert!(err.contains("Expected 0-1"));
+    }
+
+    #[test]
+    fn model_options_reject_empty_string_for_string_typed_option() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."openai/gpt-4o-transcribe"]
+            prompt = ""
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("prompt"));
+        assert!(err.contains("must not be empty"));
+    }
+
+    #[test]
+    fn model_options_reject_empty_string_for_bool_or_string_option() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-3"]
+            language = ""
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("language"));
+        assert!(err.contains("must not be empty"));
     }
 
     #[test]

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1083,6 +1083,69 @@ model = "whisper-1"
     }
 
     #[test]
+    fn model_options_allow_local_whisper_options_per_model() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."local/tiny"]
+            language = "sv"
+            no_timestamps = true
+            no_context = false
+            temperature = 0.0
+            entropy_thold = 2.4
+            no_speech_thold = 0.6
+
+            [model_options."local/turbo"]
+            language = "en"
+            temperature = 0.2
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_invalid_local_whisper_values() {
+        let cases = [
+            ("temperature = 1.5", "Expected 0-1"),
+            ("entropy_thold = -1.0", "Expected >= 0"),
+            ("no_speech_thold = 1.5", "Expected 0-1"),
+        ];
+
+        for (setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."local/turbo"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_reject_unsafe_local_model_id() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."local/Turbo"]
+            language = "en"
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("Local model id"));
+    }
+
+    #[test]
     fn model_options_reject_wrong_value_types() {
         let cases = [
             (

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+use crate::transcription::{api, model};
+
 fn current_config_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
@@ -72,139 +74,8 @@ fn default_reference_level_db() -> i8 {
     -20
 }
 
-/// Deepgram API configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeepgramConfig {
-    /// Include filler words in transcript (uh, um, etc.)
-    #[serde(default)]
-    pub filler_words: bool,
-    /// Convert spoken measurements to abbreviations
-    #[serde(default)]
-    pub measurements: bool,
-    /// Convert numbers from written to numerical format
-    #[serde(default)]
-    pub numerals: bool,
-    /// Split audio into paragraphs for readability
-    #[serde(default)]
-    pub paragraphs: bool,
-    /// Apply profanity filtering
-    #[serde(default)]
-    pub profanity_filter: bool,
-    /// Add punctuation and capitalization
-    #[serde(default)]
-    pub punctuate: bool,
-    /// Apply smart formatting to transcript
-    #[serde(default)]
-    pub smart_format: bool,
-    /// Segment speech into meaningful semantic units
-    #[serde(default)]
-    pub utterances: bool,
-    /// Seconds to wait before detecting pause between words
-    #[serde(default = "default_utt_split")]
-    pub utt_split: f64,
-    /// Enable automatic language detection
-    #[serde(default = "default_true")]
-    pub detect_language: bool,
-    /// Restrict language detection to specific languages (e.g., ["en", "es"])
-    /// When empty, all languages can be detected
-    #[serde(default)]
-    pub detect_language_codes: Vec<String>,
-    /// Opt out from Deepgram Model Improvement Program
-    #[serde(default)]
-    pub mip_opt_out: bool,
-}
-
 fn default_true() -> bool {
     true
-}
-
-fn default_utt_split() -> f64 {
-    0.8
-}
-
-impl Default for DeepgramConfig {
-    fn default() -> Self {
-        Self {
-            filler_words: false,
-            measurements: false,
-            numerals: false,
-            paragraphs: false,
-            profanity_filter: false,
-            punctuate: false,
-            smart_format: false,
-            utterances: false,
-            utt_split: default_utt_split(),
-            detect_language: true,
-            detect_language_codes: Vec::new(),
-            mip_opt_out: false,
-        }
-    }
-}
-
-/// OpenAI API configuration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct OpenAiConfig {
-    // Currently no additional parameters beyond what's in API
-    // Add here as OpenAI features become configurable
-}
-
-/// Options for AssemblyAI automatic language detection.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct LanguageDetectionOptions {
-    /// List of languages expected in the audio file.
-    /// Defaults to ["all"] when unspecified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expected_languages: Option<Vec<String>>,
-    /// Fallback language if detected language is not in expected_languages.
-    /// Use "auto" to let the model choose from expected_languages with highest confidence.
-    /// Defaults to "auto".
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fallback_language: Option<String>,
-}
-
-/// AssemblyAI API configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssemblyAIConfig {
-    /// Apply text formatting (punctuation, casing, numerals)
-    #[serde(default = "default_true")]
-    pub format_text: bool,
-    /// Include disfluencies (uh, um) in transcript
-    #[serde(default)]
-    pub disfluencies: bool,
-    /// Filter profanity from transcript
-    #[serde(default)]
-    pub filter_profanity: bool,
-    /// Enable automatic language detection
-    #[serde(default = "default_true")]
-    pub language_detection: bool,
-    /// Options for automatic language detection
-    #[serde(default)]
-    pub language_detection_options: LanguageDetectionOptions,
-    /// Enable automatic punctuation
-    #[serde(default = "default_true")]
-    pub punctuate: bool,
-}
-
-impl Default for AssemblyAIConfig {
-    fn default() -> Self {
-        Self {
-            format_text: true,
-            disfluencies: false,
-            filter_profanity: false,
-            language_detection: true,
-            language_detection_options: LanguageDetectionOptions::default(),
-            punctuate: true,
-        }
-    }
-}
-
-/// ElevenLabs Scribe API configuration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ElevenLabsConfig {
-    /// Optional ISO-639-1 or ISO-639-3 language code (e.g. "eng", "swe").
-    /// When set, can improve accuracy for known languages.
-    /// Defaults to null (auto-detect).
-    pub language_code: Option<String>,
 }
 
 /// Local transcription provider configuration.
@@ -263,42 +134,25 @@ fn validate_local_values(
     Ok(())
 }
 
-/// Mistral Voxtral API configuration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct MistralConfig {
-    /// Optional language code for transcription (e.g. "en", "sv").
-    /// When set, can improve accuracy for known languages.
-    /// Defaults to null (auto-detect).
-    pub language: Option<String>,
-}
-
-/// Provider-specific configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ProviderConfig {
-    /// Deepgram provider configuration
-    #[serde(rename = "deepgram")]
-    Deepgram(DeepgramConfig),
-    /// OpenAI provider configuration
-    #[serde(rename = "openai")]
-    OpenAi(OpenAiConfig),
-}
-
 /// All provider configurations
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct ProvidersConfig {
     #[serde(default)]
-    pub deepgram: DeepgramConfig,
-    #[serde(default)]
-    pub openai: OpenAiConfig,
-    #[serde(default)]
-    pub assemblyai: AssemblyAIConfig,
-    #[serde(default)]
-    pub elevenlabs: ElevenLabsConfig,
-    #[serde(default)]
     pub local: LocalTranscriptionConfig,
-    #[serde(default)]
-    pub mistral: MistralConfig,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ModelOptionValue {
+    Bool(bool),
+    Integer(i64),
+    Number(f64),
+    String(String),
+    StringList(Vec<String>),
+}
+
+pub type ModelOptionsConfig = IndexMap<String, IndexMap<String, ModelOptionValue>>;
 
 /// Popup window configuration for the `launch` subcommand.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -688,6 +542,8 @@ pub struct OsttConfig {
     #[serde(default)]
     pub providers: ProvidersConfig,
     #[serde(default)]
+    pub model_options: ModelOptionsConfig,
+    #[serde(default)]
     pub process: ProcessConfig,
     #[serde(default)]
     pub popup: PopupConfig,
@@ -705,6 +561,7 @@ impl OsttConfig {
         let config_content = fs::read_to_string(&config_path)?;
         let config: OsttConfig = toml::from_str(&config_content)?;
         config.providers.local.validate()?;
+        validate_model_options(&config.model_options)?;
         for action in &config.process.actions {
             action.validate()?;
         }
@@ -738,6 +595,7 @@ impl OsttConfig {
             },
             transcription: TranscriptionSelectionConfig::default(),
             providers: ProvidersConfig::default(),
+            model_options: ModelOptionsConfig::default(),
             process: ProcessConfig::default(),
             popup: PopupConfig::default(),
         }
@@ -762,6 +620,105 @@ pub(crate) fn get_config_path() -> Result<PathBuf, std::io::Error> {
 /// - If the config file cannot be written
 pub fn save_config(config: &OsttConfig) -> anyhow::Result<()> {
     config.save()
+}
+
+pub fn validate_model_options(model_options: &ModelOptionsConfig) -> anyhow::Result<()> {
+    for (full_model_id, options) in model_options {
+        let (provider_id, model_id) = full_model_id.split_once('/').ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invalid model_options key '{}'. Use 'provider/model'.",
+                full_model_id
+            )
+        })?;
+
+        if provider_id != "local" && model::find_model(provider_id, model_id).is_none() {
+            anyhow::bail!(
+                "Invalid model_options key '{}'. Unknown provider/model.",
+                full_model_id
+            );
+        }
+
+        let schema = api::option_schema(provider_id, model_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invalid model_options key '{}'. No options are supported for this model.",
+                full_model_id
+            )
+        })?;
+
+        for (option_name, value) in options {
+            let Some(spec) = schema.option(option_name) else {
+                anyhow::bail!(
+                    "Invalid option '{}' for '{}'. Supported options: {}.",
+                    option_name,
+                    full_model_id,
+                    schema.option_names().join(", ")
+                );
+            };
+            validate_model_option_type(full_model_id, option_name, value, spec.kind)?;
+        }
+
+        api::validate_model_options(provider_id, full_model_id, options)?;
+    }
+
+    Ok(())
+}
+
+fn validate_model_option_type(
+    full_model_id: &str,
+    option_name: &str,
+    value: &ModelOptionValue,
+    expected: model::ModelOptionKind,
+) -> anyhow::Result<()> {
+    let matches = matches!(
+        (expected, value),
+        (model::ModelOptionKind::Bool, ModelOptionValue::Bool(_))
+            | (
+                model::ModelOptionKind::BoolOrString,
+                ModelOptionValue::Bool(_)
+            )
+            | (
+                model::ModelOptionKind::BoolOrString,
+                ModelOptionValue::String(_)
+            )
+            | (
+                model::ModelOptionKind::BoolOrStringList,
+                ModelOptionValue::Bool(_),
+            )
+            | (
+                model::ModelOptionKind::BoolOrStringList,
+                ModelOptionValue::StringList(_),
+            )
+            | (
+                model::ModelOptionKind::Integer,
+                ModelOptionValue::Integer(_)
+            )
+            | (model::ModelOptionKind::Number, ModelOptionValue::Number(_))
+            | (model::ModelOptionKind::Number, ModelOptionValue::Integer(_))
+            | (model::ModelOptionKind::String, ModelOptionValue::String(_))
+            | (
+                model::ModelOptionKind::StringOrStringList,
+                ModelOptionValue::String(_),
+            )
+            | (
+                model::ModelOptionKind::StringOrStringList,
+                ModelOptionValue::StringList(_),
+            )
+            | (
+                model::ModelOptionKind::StringList,
+                ModelOptionValue::StringList(_)
+            )
+    );
+
+    if !matches {
+        anyhow::bail!(
+            "Invalid value for option '{}' in '{}'. Expected {}.",
+            option_name,
+            full_model_id,
+            expected.name()
+        );
+    }
+
+    Ok(())
 }
 
 pub fn ensure_local_transcription_audio_config() -> anyhow::Result<()> {
@@ -893,6 +850,7 @@ model = "whisper-1"
 
     fn validate_ostt_config(config: &OsttConfig) -> anyhow::Result<()> {
         config.providers.local.validate()?;
+        validate_model_options(&config.model_options)?;
         for action in &config.process.actions {
             action
                 .validate()
@@ -1081,6 +1039,602 @@ model = "whisper-1"
 
         let config = parse_ostt_config(toml_str).unwrap();
         validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_validate_against_model_schema() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-3"]
+            detect_language = ["sv", "en"]
+            smart_format = true
+            keyterm = ["OSTT"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_wrong_value_types() {
+        let cases = [
+            (
+                "deepgram/nova-3",
+                "smart_format = \"true\"",
+                "smart_format",
+                "boolean",
+            ),
+            (
+                "openai/gpt-4o-transcribe",
+                "temperature = \"0.2\"",
+                "temperature",
+                "number",
+            ),
+            (
+                "openai/gpt-4o-transcribe",
+                "prompt = [\"OSTT\"]",
+                "prompt",
+                "string",
+            ),
+            (
+                "deepgram/nova-3",
+                "keyterm = \"OSTT\"",
+                "keyterm",
+                "string list",
+            ),
+            (
+                "elevenlabs/scribe_v2",
+                "num_speakers = \"2\"",
+                "num_speakers",
+                "integer",
+            ),
+        ];
+
+        for (model_id, setting, option_name, expected_type) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."{model_id}"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(option_name), "{err}");
+            assert!(err.contains(expected_type), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_accept_bool_or_string_list_shapes() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-3"]
+            detect_language = true
+
+            [model_options."deepgram/nova-2"]
+            detect_language = ["en", "sv"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_invalid_bool_or_string_list_shape() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-3"]
+            detect_language = "en,sv"
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("detect_language"));
+        assert!(err.contains("boolean or string list"));
+    }
+
+    #[test]
+    fn model_options_reject_duplicate_config_keys_at_parse_time() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-3"]
+            smart_format = true
+            smart_format = false
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("duplicate key") || err.contains("duplicate field"));
+    }
+
+    #[test]
+    fn model_options_reject_unknown_option_for_model() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."openai/gpt-4o-transcribe"]
+            smart_format = true
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("Invalid option 'smart_format'"));
+    }
+
+    #[test]
+    fn model_options_allow_openai_documented_json_safe_options() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."openai/gpt-4o-transcribe"]
+            include = ["logprobs"]
+
+            [model_options."openai/whisper-1"]
+            response_format = "verbose_json"
+            timestamp_granularities = ["word", "segment"]
+
+            [model_options."openai/gpt-4o-transcribe-diarize"]
+            response_format = "diarized_json"
+            chunking_strategy = "auto"
+            known_speaker_names = ["agent"]
+            known_speaker_references = ["data:audio/wav;base64,AAA..."]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_openai_options_that_break_json_parsing_or_api_rules() {
+        let cases = [
+            (
+                "openai/gpt-4o-transcribe",
+                "include = [\"timestamps\"]",
+                "include",
+            ),
+            (
+                "openai/whisper-1",
+                "response_format = \"srt\"",
+                "response_format",
+            ),
+            (
+                "openai/whisper-1",
+                "timestamp_granularities = [\"sentence\"]",
+                "timestamp_granularities",
+            ),
+            (
+                "openai/whisper-1",
+                "response_format = \"json\"\ntimestamp_granularities = [\"word\"]",
+                "verbose_json",
+            ),
+            (
+                "openai/gpt-4o-transcribe-diarize",
+                "chunking_strategy = \"none\"",
+                "chunking_strategy",
+            ),
+        ];
+
+        for (model_id, setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."{model_id}"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_reject_model_specific_deepgram_keyterm() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-2"]
+            keyterm = ["OSTT"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("Invalid option 'keyterm'"));
+    }
+
+    #[test]
+    fn model_options_allow_deepgram_nova_2_keywords() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepgram/nova-2"]
+            keywords = ["OSTT"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_model_specific_elevenlabs_v2_option_on_v1() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."elevenlabs/scribe_v1"]
+            no_verbatim = true
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("Invalid option 'no_verbatim'"));
+    }
+
+    #[test]
+    fn model_options_allow_elevenlabs_documented_options() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."elevenlabs/scribe_v2"]
+            language_code = "en"
+            tag_audio_events = true
+            timestamps_granularity = "word"
+            diarize = true
+            detect_speaker_roles = true
+            diarization_threshold = 0.2
+            temperature = 1.5
+            file_format = "other"
+            seed = 42
+            use_multi_channel = false
+            keyterms = ["OSTT"]
+            no_verbatim = true
+            entity_detection = ["pii", "phi"]
+            entity_redaction = "pii"
+            entity_redaction_mode = "enumerated_entity_type"
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_invalid_elevenlabs_values() {
+        let cases = [
+            (
+                "timestamps_granularity = \"sentence\"",
+                "timestamps_granularity",
+            ),
+            ("file_format = \"wav\"", "file_format"),
+            (
+                "entity_redaction_mode = \"masked\"",
+                "entity_redaction_mode",
+            ),
+            (
+                "diarize = false\ndiarization_threshold = 0.2",
+                "diarization_threshold requires diarize",
+            ),
+            (
+                "diarize = true\nnum_speakers = 2\ndiarization_threshold = 0.2",
+                "diarization_threshold cannot be used with num_speakers",
+            ),
+            (
+                "detect_speaker_roles = true",
+                "detect_speaker_roles requires diarize",
+            ),
+            (
+                "diarize = true\ndetect_speaker_roles = true\nuse_multi_channel = true",
+                "detect_speaker_roles cannot be used with use_multi_channel",
+            ),
+        ];
+
+        for (setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."elevenlabs/scribe_v2"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_reject_berget_only_hotwords_on_groq() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."groq/whisper-large-v3"]
+            hotwords = ["OSTT"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("Invalid option 'hotwords'"));
+    }
+
+    #[test]
+    fn model_options_allow_berget_openapi_options() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."berget/KBLab/kb-whisper-large"]
+            language = "sv"
+            hotwords = ["OSTT", "Berget"]
+            prompt = "Swedish technical dictation."
+            temperature = 0.0
+            response_format = "verbose_json"
+            timestamp_granularities = ["word", "segment"]
+            align = true
+            diarize = true
+            speaker_embeddings = true
+            chunk_size = 30
+            batch_size = 8
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_invalid_berget_values() {
+        let cases = [
+            ("response_format = \"srt\"", "response_format"),
+            (
+                "timestamp_granularities = [\"sentence\"]",
+                "timestamp_granularities",
+            ),
+            ("chunk_size = 0", "chunk_size"),
+            ("chunk_size = 61", "chunk_size"),
+            ("batch_size = 0", "batch_size"),
+            ("batch_size = 33", "batch_size"),
+            ("stream = true", "Invalid option 'stream'"),
+        ];
+
+        for (setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."berget/openai/whisper-large-v3"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_allow_deepinfra_documented_options_and_models() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."deepinfra/openai/whisper-large-v3-turbo"]
+            task = "transcribe"
+            initial_prompt = "Names: OSTT, DeepInfra, Whisper."
+            language = "en"
+            temperature = 0.0
+            chunk_level = "word"
+            chunk_length_s = 30
+
+            [model_options."deepinfra/mistralai/Voxtral-Mini-3B-2507"]
+            task = "transcribe"
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_invalid_deepinfra_values() {
+        let cases = [
+            ("task = \"summarize\"", "task"),
+            ("chunk_level = \"sentence\"", "chunk_level"),
+            ("chunk_length_s = 31", "chunk_length_s"),
+            ("prompt = \"OSTT\"", "Invalid option 'prompt'"),
+        ];
+
+        for (setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."deepinfra/openai/whisper-large-v3"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_allow_groq_documented_json_safe_options() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."groq/whisper-large-v3-turbo"]
+            response_format = "verbose_json"
+            timestamp_granularities = ["word", "segment"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_groq_options_that_break_json_parsing_or_api_rules() {
+        let cases = [
+            ("response_format = \"text\"", "response_format"),
+            (
+                "timestamp_granularities = [\"sentence\"]",
+                "timestamp_granularities",
+            ),
+            (
+                "response_format = \"json\"\ntimestamp_granularities = [\"word\"]",
+                "verbose_json",
+            ),
+        ];
+
+        for (setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."groq/whisper-large-v3"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_allow_mistral_documented_options() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."mistral/voxtral-mini-latest"]
+            language = "sv"
+            diarize = true
+            context_bias = ["OSTT"]
+            temperature = 0.2
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_allow_mistral_timestamp_granularities() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."mistral/voxtral-mini-latest"]
+            context_bias = ["OSTT"]
+            diarize = true
+            timestamp_granularities = ["word"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn model_options_reject_invalid_mistral_values() {
+        let cases = [
+            (
+                "timestamp_granularities = [\"sentence\"]",
+                "timestamp_granularities",
+            ),
+            (
+                "language = \"en\"\ntimestamp_granularities = [\"word\"]",
+                "not compatible with language",
+            ),
+        ];
+
+        for (setting, expected) in cases {
+            let toml_str = format!(
+                r#"
+                    [audio]
+                    device = "default"
+
+                    [model_options."mistral/voxtral-mini-latest"]
+                    {setting}
+                "#
+            );
+
+            let config = parse_ostt_config(&toml_str).unwrap();
+            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            assert!(err.contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn model_options_reject_assemblyai_prompt_with_keyterms_prompt() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."assemblyai/universal-3-pro"]
+            prompt = "Use Swedish spelling."
+            keyterms_prompt = ["OSTT"]
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("prompt"));
+        assert!(err.contains("keyterms_prompt"));
+    }
+
+    #[test]
+    fn model_options_reject_out_of_range_values() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options."openai/gpt-4o-transcribe"]
+            temperature = 1.5
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        let err = validate_ostt_config(&config).unwrap_err().to_string();
+        assert!(err.contains("Expected 0-1"));
+    }
+
+    #[test]
+    fn old_provider_level_request_options_fail_deserialization() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [providers.deepgram]
+            smart_format = true
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("unknown field `deepgram`"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,8 +14,8 @@ pub use file::{
     ProcessConfig,
 };
 pub use file::{
-    AudioConfig, OsttConfig, PopupConfig, ProvidersConfig, TranscriptionSelectionConfig,
-    VisualizationType,
+    AudioConfig, ModelOptionValue, ModelOptionsConfig, OsttConfig, PopupConfig, ProvidersConfig,
+    TranscriptionSelectionConfig, VisualizationType,
 };
 pub use secrets::{
     clear_api_key, clear_selected_model, get_api_key, get_authorized_providers, get_selected_model,

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -16,6 +16,98 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[ModelSpec {
+    provider_id: "assemblyai",
+    model_id: "universal-3-pro",
+    endpoint: "https://api.assemblyai.com/v2",
+    display_name: "Universal 3 Pro (best accuracy)",
+    description: "AssemblyAI's Universal-3 Pro speech-to-text model for high-accuracy transcription and audio understanding in cloud workflows.",
+    languages: &["Multilingual"],
+}];
+
+const OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "boost_param",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "disfluencies",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "filter_profanity",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "format_text",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "language_detection",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "language_code",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "keyterms_prompt",
+        kind: ModelOptionKind::StringList,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "punctuate",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "speaker_labels",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "speakers_expected",
+        kind: ModelOptionKind::Integer,
+    },
+    ModelOptionSpec {
+        name: "speech_threshold",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "word_boost",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+pub(super) fn option_schema(_model_id: &str) -> Option<ModelOptionSchema> {
+    Some(ModelOptionSchema::new(OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "speech_threshold", 0.0..=1.0)?;
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    if options.contains_key("prompt") && options.contains_key("keyterms_prompt") {
+        anyhow::bail!(
+            "Invalid options for '{}'. AssemblyAI does not allow 'prompt' and 'keyterms_prompt' together.",
+            full_model_id
+        );
+    }
+
+    Ok(())
+}
 
 /// Maximum number of poll attempts before timing out (5 minutes at 3-second intervals)
 const MAX_POLL_ATTEMPTS: u32 = 100;
@@ -64,6 +156,22 @@ struct TranscriptRequest {
     punctuate: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     keyterms_prompt: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speaker_labels: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speakers_expected: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speech_threshold: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    word_boost: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    boost_param: Option<String>,
 }
 
 /// Response from the transcription endpoint (both submit and poll)
@@ -94,52 +202,44 @@ pub(super) async fn transcribe(
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to create HTTP client: {e}"))?;
 
-    let base_url = config.endpoint();
+    let base_url = config.endpoint;
 
     // Step 1: Upload audio with retry logic for transient failures
     let upload_url = upload_with_retry(&client, base_url, &config.api_key, audio_data).await?;
 
     // Step 2: Submit transcription request
-    let assemblyai_config = &config.providers.assemblyai;
-
     // Build language_detection_options if any values are set
-    let language_detection_options = if assemblyai_config
-        .language_detection_options
-        .expected_languages
-        .is_some()
-        || assemblyai_config
-            .language_detection_options
-            .fallback_language
-            .is_some()
-    {
-        Some(LanguageDetectionOptionsRequest {
-            expected_languages: assemblyai_config
-                .language_detection_options
-                .expected_languages
-                .clone(),
-            fallback_language: assemblyai_config
-                .language_detection_options
-                .fallback_language
-                .clone(),
-        })
-    } else {
-        None
-    };
+    let language_detection_options = None;
 
     let mut request = TranscriptRequest {
         audio_url: upload_url,
         speech_models: Some(vec![config.model_id.clone()]),
-        format_text: Some(assemblyai_config.format_text),
-        disfluencies: Some(assemblyai_config.disfluencies),
-        filter_profanity: Some(assemblyai_config.filter_profanity),
-        language_detection: Some(assemblyai_config.language_detection),
+        format_text: Some(config.option_bool("format_text").unwrap_or(true)),
+        disfluencies: Some(config.option_bool("disfluencies").unwrap_or(false)),
+        filter_profanity: Some(config.option_bool("filter_profanity").unwrap_or(false)),
+        language_detection: Some(config.option_bool("language_detection").unwrap_or(true)),
         language_detection_options,
-        punctuate: Some(assemblyai_config.punctuate),
-        keyterms_prompt: None,
+        punctuate: Some(config.option_bool("punctuate").unwrap_or(true)),
+        keyterms_prompt: config
+            .option_string_list("keyterms_prompt")
+            .map(ToOwned::to_owned),
+        language_code: config
+            .option_string("language_code")
+            .map(ToString::to_string),
+        prompt: config.option_string("prompt").map(ToString::to_string),
+        speaker_labels: config.option_bool("speaker_labels"),
+        speakers_expected: config.option_integer("speakers_expected"),
+        speech_threshold: config.option_number("speech_threshold"),
+        temperature: config.option_number("temperature"),
+        word_boost: config
+            .option_string_list("word_boost")
+            .map(ToOwned::to_owned),
+        boost_param: config.option_string("boost_param").map(ToString::to_string),
     };
 
-    // Add keywords as keyterms_prompt if any
-    if !config.keywords.is_empty() {
+    // AssemblyAI rejects `prompt` and `keyterms_prompt` together.
+    if request.prompt.is_none() && request.keyterms_prompt.is_none() && !config.keywords.is_empty()
+    {
         request.keyterms_prompt = Some(config.keywords.clone());
     }
 

--- a/src/transcription/api/berget.rs
+++ b/src/transcription/api/berget.rs
@@ -6,6 +6,117 @@ use serde::Deserialize;
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "berget",
+        model_id: "KBLab/kb-whisper-large",
+        endpoint: "https://api.berget.ai/v1/audio/transcriptions",
+        display_name: "KBLab KB Whisper Large (Swedish optimized)",
+        description: "KBLab's Swedish-optimized Whisper Large model from the National Library of Sweden, trained on more than 50,000 hours of Swedish speech. KBLab reports substantially lower Swedish WER than OpenAI Whisper Large V3 across FLEURS, CommonVoice, and NST evaluations.",
+        languages: &["Swedish"],
+    },
+    ModelSpec {
+        provider_id: "berget",
+        model_id: "NbAiLab/nb-whisper-large",
+        endpoint: "https://api.berget.ai/v1/audio/transcriptions",
+        display_name: "NbAiLab NB Whisper Large (Norwegian optimized)",
+        description: "NbAiLab's Norwegian NB-Whisper Large model from the National Library of Norway. It is trained on about 66,000 hours of speech and targets Norwegian ASR, including Bokmal, Nynorsk, English, and varied regional Norwegian speech.",
+        languages: &["Norwegian", "Bokmal", "Nynorsk", "English"],
+    },
+    ModelSpec {
+        provider_id: "berget",
+        model_id: "openai/whisper-large-v3",
+        endpoint: "https://api.berget.ai/v1/audio/transcriptions",
+        display_name: "OpenAI Whisper Large V3 (general-purpose)",
+        description: "General-purpose OpenAI Whisper Large V3 hosted through Berget for multilingual transcription and translation when no Swedish- or Norwegian-specialized model is preferred.",
+        languages: &["Multilingual"],
+    },
+];
+
+const OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "hotwords",
+        kind: ModelOptionKind::StringList,
+    },
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "response_format",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "timestamp_granularities",
+        kind: ModelOptionKind::StringList,
+    },
+    ModelOptionSpec {
+        name: "align",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "diarize",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "speaker_embeddings",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "chunk_size",
+        kind: ModelOptionKind::Integer,
+    },
+    ModelOptionSpec {
+        name: "batch_size",
+        kind: ModelOptionKind::Integer,
+    },
+];
+
+pub(super) fn option_schema(_model_id: &str) -> Option<ModelOptionSchema> {
+    Some(ModelOptionSchema::new(OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    if let Some(value) = options.get("response_format") {
+        super::validate_string_value(
+            full_model_id,
+            "response_format",
+            value,
+            &["json", "verbose_json"],
+        )?;
+    }
+
+    if let Some(value) = options.get("timestamp_granularities") {
+        super::validate_string_list_values(
+            full_model_id,
+            "timestamp_granularities",
+            value,
+            &["word", "segment"],
+        )?;
+    }
+
+    super::validate_integer_range(full_model_id, options, "chunk_size", 1..=60)?;
+    super::validate_integer_range(full_model_id, options, "batch_size", 1..=32)?;
+
+    Ok(())
+}
 
 /// Berget API response wrapper
 #[derive(Debug, Deserialize)]
@@ -47,17 +158,63 @@ pub(super) async fn transcribe(
     // Debug log: Log the API call details (without the audio data)
     let mut debug_params = vec![format!("model={}", config.model_id)];
 
-    // Add keywords as hotwords (Berget-specific) and prompt (Whisper-compatible)
-    if !config.keywords.is_empty() {
-        let keywords_csv = config.keywords.join(", ");
-        form = form.text("hotwords", keywords_csv.clone());
-        form = form.text("prompt", keywords_csv.clone());
-        debug_params.push(format!("hotwords={keywords_csv}"));
-        debug_params.push(format!("prompt={keywords_csv}"));
-        tracing::debug!("Keywords used for Berget model: {:?}", config.keywords);
+    if let Some(language) = config.option_string("language") {
+        if !language.is_empty() {
+            form = form.text("language", language.to_string());
+            debug_params.push(format!("language={language}"));
+        }
     }
 
-    let endpoint = config.endpoint();
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+        debug_params.push(format!("temperature={temperature}"));
+    }
+
+    let hotwords = config
+        .option_string_list("hotwords")
+        .map(|values| values.join(", "))
+        .or_else(|| (!config.keywords.is_empty()).then(|| config.keywords.join(", ")));
+    if let Some(hotwords) = hotwords {
+        form = form.text("hotwords", hotwords.clone());
+        debug_params.push(format!("hotwords={hotwords}"));
+    }
+    let prompt = config
+        .option_string("prompt")
+        .map(ToString::to_string)
+        .or_else(|| (!config.keywords.is_empty()).then(|| config.keywords.join(", ")));
+    if let Some(prompt) = prompt {
+        form = form.text("prompt", prompt.clone());
+        debug_params.push(format!("prompt={prompt}"));
+        tracing::debug!("Prompt used for Berget model: {prompt}");
+    }
+
+    if let Some(response_format) = response_format(config) {
+        form = form.text("response_format", response_format.to_string());
+        debug_params.push(format!("response_format={response_format}"));
+    }
+
+    if let Some(granularities) = config.option_string_list("timestamp_granularities") {
+        for granularity in granularities {
+            form = form.text("timestamp_granularities[]", granularity.clone());
+            debug_params.push(format!("timestamp_granularities[]={granularity}"));
+        }
+    }
+
+    for option_name in ["align", "diarize", "speaker_embeddings"] {
+        if let Some(value) = config.option_bool(option_name) {
+            form = form.text(option_name.to_string(), value.to_string());
+            debug_params.push(format!("{option_name}={value}"));
+        }
+    }
+
+    for option_name in ["chunk_size", "batch_size"] {
+        if let Some(value) = config.option_integer(option_name) {
+            form = form.text(option_name.to_string(), value.to_string());
+            debug_params.push(format!("{option_name}={value}"));
+        }
+    }
+
+    let endpoint = config.endpoint;
 
     tracing::debug!(
         "Berget API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",
@@ -121,4 +278,21 @@ pub(super) async fn transcribe(
     );
 
     Ok(berget_response.text.trim().to_string())
+}
+
+fn response_format(config: &TranscriptionConfig) -> Option<&str> {
+    if let Some(response_format) = config.option_string("response_format") {
+        return Some(response_format);
+    }
+
+    if config
+        .option_string_list("timestamp_granularities")
+        .is_some_and(|granularities| !granularities.is_empty())
+        || config.option_bool("align") == Some(true)
+        || config.option_bool("diarize") == Some(true)
+    {
+        return Some("verbose_json");
+    }
+
+    Some("json")
 }

--- a/src/transcription/api/deepgram.rs
+++ b/src/transcription/api/deepgram.rs
@@ -7,6 +7,156 @@ use std::path::Path;
 use urlencoding;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "deepgram",
+        model_id: "nova-3",
+        endpoint: "https://api.deepgram.com/v1/listen",
+        display_name: "Nova 3 (latest, fastest)",
+        description: "Deepgram's highest-performing general-purpose ASR model for batch or streaming use cases including meetings, event captioning, multi-speaker audio, noisy audio, far-field audio, and multilingual transcription.",
+        languages: &["Multilingual", "Swedish", "Norwegian", "English"],
+    },
+    ModelSpec {
+        provider_id: "deepgram",
+        model_id: "nova-2",
+        endpoint: "https://api.deepgram.com/v1/listen",
+        display_name: "Nova 2 (previous generation)",
+        description: "Deepgram's previous-generation Nova model. Useful when a language or feature is better covered by Nova 2, including filler word identification and broad multilingual speech recognition.",
+        languages: &["Multilingual", "Swedish", "Norwegian", "English"],
+    },
+];
+
+const fn option(name: &'static str, kind: ModelOptionKind) -> ModelOptionSpec {
+    ModelOptionSpec { name, kind }
+}
+
+const NOVA_3_OPTIONS: &[ModelOptionSpec] = &[
+    option("custom_intent", ModelOptionKind::StringList),
+    option("custom_intent_mode", ModelOptionKind::String),
+    option("custom_topic", ModelOptionKind::StringList),
+    option("custom_topic_mode", ModelOptionKind::String),
+    option("detect_entities", ModelOptionKind::Bool),
+    option("detect_language", ModelOptionKind::BoolOrStringList),
+    option("diarize", ModelOptionKind::Bool),
+    option("diarize_model", ModelOptionKind::String),
+    option("dictation", ModelOptionKind::Bool),
+    option("encoding", ModelOptionKind::String),
+    option("extra", ModelOptionKind::StringList),
+    option("filler_words", ModelOptionKind::Bool),
+    option("intents", ModelOptionKind::Bool),
+    option("keyterm", ModelOptionKind::StringList),
+    option("keywords", ModelOptionKind::StringList),
+    option("language", ModelOptionKind::String),
+    option("measurements", ModelOptionKind::Bool),
+    option("mip_opt_out", ModelOptionKind::Bool),
+    option("multichannel", ModelOptionKind::Bool),
+    option("numerals", ModelOptionKind::Bool),
+    option("paragraphs", ModelOptionKind::Bool),
+    option("profanity_filter", ModelOptionKind::Bool),
+    option("punctuate", ModelOptionKind::Bool),
+    option("redact", ModelOptionKind::StringList),
+    option("replace", ModelOptionKind::StringList),
+    option("search", ModelOptionKind::StringList),
+    option("sentiment", ModelOptionKind::Bool),
+    option("smart_format", ModelOptionKind::Bool),
+    option("summarize", ModelOptionKind::BoolOrString),
+    option("tag", ModelOptionKind::StringList),
+    option("topics", ModelOptionKind::Bool),
+    option("utterances", ModelOptionKind::Bool),
+    option("utt_split", ModelOptionKind::Number),
+    option("version", ModelOptionKind::String),
+];
+
+const NOVA_2_OPTIONS: &[ModelOptionSpec] = &[
+    option("custom_intent", ModelOptionKind::StringList),
+    option("custom_intent_mode", ModelOptionKind::String),
+    option("custom_topic", ModelOptionKind::StringList),
+    option("custom_topic_mode", ModelOptionKind::String),
+    option("detect_entities", ModelOptionKind::Bool),
+    option("detect_language", ModelOptionKind::BoolOrStringList),
+    option("diarize", ModelOptionKind::Bool),
+    option("diarize_model", ModelOptionKind::String),
+    option("dictation", ModelOptionKind::Bool),
+    option("encoding", ModelOptionKind::String),
+    option("extra", ModelOptionKind::StringList),
+    option("filler_words", ModelOptionKind::Bool),
+    option("intents", ModelOptionKind::Bool),
+    option("keywords", ModelOptionKind::StringList),
+    option("language", ModelOptionKind::String),
+    option("measurements", ModelOptionKind::Bool),
+    option("mip_opt_out", ModelOptionKind::Bool),
+    option("multichannel", ModelOptionKind::Bool),
+    option("numerals", ModelOptionKind::Bool),
+    option("paragraphs", ModelOptionKind::Bool),
+    option("profanity_filter", ModelOptionKind::Bool),
+    option("punctuate", ModelOptionKind::Bool),
+    option("redact", ModelOptionKind::StringList),
+    option("replace", ModelOptionKind::StringList),
+    option("search", ModelOptionKind::StringList),
+    option("sentiment", ModelOptionKind::Bool),
+    option("smart_format", ModelOptionKind::Bool),
+    option("summarize", ModelOptionKind::BoolOrString),
+    option("tag", ModelOptionKind::StringList),
+    option("topics", ModelOptionKind::Bool),
+    option("utterances", ModelOptionKind::Bool),
+    option("utt_split", ModelOptionKind::Number),
+    option("version", ModelOptionKind::String),
+];
+
+pub(super) fn option_schema(model_id: &str) -> Option<ModelOptionSchema> {
+    match model_id {
+        "nova-3" => Some(ModelOptionSchema::new(NOVA_3_OPTIONS)),
+        "nova-2" => Some(ModelOptionSchema::new(NOVA_2_OPTIONS)),
+        _ => None,
+    }
+}
+
+fn push_query_pair(url: &mut String, name: &str, value: &str) {
+    url.push_str(&format!("&{}={}", name, urlencoding::encode(value)));
+}
+
+fn push_bool_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
+    if let Some(value) = config.option_bool(name) {
+        url.push_str(&format!("&{name}={value}"));
+    }
+}
+
+fn push_string_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
+    if let Some(value) = config.option_string(name) {
+        push_query_pair(url, name, value);
+    }
+}
+
+fn push_string_list_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
+    if let Some(values) = config.option_string_list(name) {
+        for value in values {
+            push_query_pair(url, name, value);
+        }
+    }
+}
+
+fn push_bool_or_string_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
+    match config.model_options.get(name) {
+        Some(ModelOptionValue::Bool(value)) => url.push_str(&format!("&{name}={value}")),
+        Some(ModelOptionValue::String(value)) => push_query_pair(url, name, value),
+        _ => {}
+    }
+}
+
+fn push_bool_or_string_list_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
+    match config.model_options.get(name) {
+        Some(ModelOptionValue::Bool(value)) => url.push_str(&format!("&{name}={value}")),
+        Some(ModelOptionValue::StringList(values)) => {
+            for value in values {
+                push_query_pair(url, name, value);
+            }
+        }
+        _ => {}
+    }
+}
 
 /// Deepgram response structure (kept for potential future use)
 #[allow(dead_code)]
@@ -48,46 +198,59 @@ pub(super) async fn transcribe(
     let client = reqwest::Client::new();
 
     // Build the API URL with query parameters
-    let mut url = format!("{}?model={}", config.endpoint(), config.model_id);
+    let mut url = format!("{}?model={}", config.endpoint, config.model_id);
 
-    // Add Deepgram feature flags from provider configuration
-    let deepgram_config = &config.providers.deepgram;
-    if deepgram_config.filler_words {
-        url.push_str("&filler_words=true");
+    for name in [
+        "detect_entities",
+        "diarize",
+        "dictation",
+        "filler_words",
+        "intents",
+        "measurements",
+        "mip_opt_out",
+        "multichannel",
+        "numerals",
+        "paragraphs",
+        "profanity_filter",
+        "punctuate",
+        "sentiment",
+        "smart_format",
+        "topics",
+        "utterances",
+    ] {
+        push_bool_option(config, &mut url, name);
     }
-    if deepgram_config.measurements {
-        url.push_str("&measurements=true");
+
+    for name in [
+        "custom_intent_mode",
+        "custom_topic_mode",
+        "diarize_model",
+        "encoding",
+        "language",
+        "version",
+    ] {
+        push_string_option(config, &mut url, name);
     }
-    if deepgram_config.numerals {
-        url.push_str("&numerals=true");
+
+    for name in [
+        "custom_intent",
+        "custom_topic",
+        "extra",
+        "keyterm",
+        "keywords",
+        "redact",
+        "replace",
+        "search",
+        "tag",
+    ] {
+        push_string_list_option(config, &mut url, name);
     }
-    if deepgram_config.paragraphs {
-        url.push_str("&paragraphs=true");
-    }
-    if deepgram_config.profanity_filter {
-        url.push_str("&profanity_filter=true");
-    }
-    if deepgram_config.punctuate {
-        url.push_str("&punctuate=true");
-    }
-    if deepgram_config.smart_format {
-        url.push_str("&smart_format=true");
-    }
-    if deepgram_config.utterances {
-        url.push_str("&utterances=true");
-    }
-    if deepgram_config.utt_split != 0.8 {
-        url.push_str(&format!("&utt_split={}", deepgram_config.utt_split));
-    }
-    if !deepgram_config.detect_language_codes.is_empty() {
-        for lang in &deepgram_config.detect_language_codes {
-            url.push_str(&format!("&detect_language={}", urlencoding::encode(lang)));
-        }
-    } else if deepgram_config.detect_language {
-        url.push_str("&detect_language=true");
-    }
-    if deepgram_config.mip_opt_out {
-        url.push_str("&mip_opt_out=true");
+
+    push_bool_or_string_list_option(config, &mut url, "detect_language");
+    push_bool_or_string_option(config, &mut url, "summarize");
+
+    if let Some(utt_split) = config.option_number("utt_split") {
+        url.push_str(&format!("&utt_split={utt_split}"));
     }
 
     // Add keywords/keyterms if any (nova-3 uses keyterms, nova-2 uses keywords)
@@ -97,8 +260,10 @@ pub(super) async fn transcribe(
         } else {
             "keywords"
         };
-        for keyword in &config.keywords {
-            url.push_str(&format!("&{}={}", param_name, urlencoding::encode(keyword)));
+        if !config.model_options.contains_key(param_name) {
+            for keyword in &config.keywords {
+                push_query_pair(&mut url, param_name, keyword);
+            }
         }
     }
 

--- a/src/transcription/api/deepinfra.rs
+++ b/src/transcription/api/deepinfra.rs
@@ -6,6 +6,134 @@ use serde::Deserialize;
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-large-v3",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Large V3 (best accuracy)",
+        description: "OpenAI Whisper Large V3 hosted through DeepInfra. A general-purpose multilingual Whisper model suited for high-accuracy transcription and translation workloads.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-large-v3-turbo",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Large V3 Turbo (fast)",
+        description: "OpenAI Whisper Large V3 Turbo hosted through DeepInfra. A pruned Large V3 variant designed for faster multilingual transcription with minor quality tradeoffs.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-large",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Large (best accuracy)",
+        description: "OpenAI Whisper Large hosted through DeepInfra. DeepInfra documents this as the best-accuracy Whisper option in its speech recognition API.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-medium",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Medium",
+        description: "OpenAI Whisper Medium hosted through DeepInfra. A lighter Whisper model for faster multilingual transcription than Whisper Large.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-small",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Small",
+        description: "OpenAI Whisper Small hosted through DeepInfra. A smaller Whisper model for lightweight multilingual transcription workloads.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-base",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Base (fast, lightweight)",
+        description: "OpenAI Whisper Base hosted through DeepInfra. A smaller Whisper model option for lighter and faster multilingual transcription workloads.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "openai/whisper-timestamped-medium",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "OpenAI Whisper Timestamped Medium",
+        description: "OpenAI Whisper Timestamped Medium hosted through DeepInfra. DeepInfra documents this model for per-word timestamp segmentation.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "mistralai/Voxtral-Mini-3B-2507",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "Mistral Voxtral Mini 3B 2507",
+        description: "Mistral Voxtral Mini hosted through DeepInfra. A 3B audio-capable model for transcription, translation, and audio understanding.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "deepinfra",
+        model_id: "mistralai/Voxtral-Small-24B-2507",
+        endpoint: "https://api.deepinfra.com/v1/inference",
+        display_name: "Mistral Voxtral Small 24B 2507",
+        description: "Mistral Voxtral Small hosted through DeepInfra. A larger audio-capable model for transcription, translation, and audio understanding.",
+        languages: &["Multilingual"],
+    },
+];
+
+const OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "initial_prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "task",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "chunk_level",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "chunk_length_s",
+        kind: ModelOptionKind::Integer,
+    },
+];
+
+pub(super) fn option_schema(_model_id: &str) -> Option<ModelOptionSchema> {
+    Some(ModelOptionSchema::new(OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    if let Some(value) = options.get("task") {
+        super::validate_string_value(full_model_id, "task", value, &["transcribe", "translate"])?;
+    }
+
+    if let Some(value) = options.get("chunk_level") {
+        super::validate_string_value(full_model_id, "chunk_level", value, &["segment", "word"])?;
+    }
+
+    super::validate_integer_range(full_model_id, options, "chunk_length_s", 1..=30)?;
+
+    Ok(())
+}
 
 /// DeepInfra API response structure
 #[derive(Debug, Deserialize)]
@@ -43,17 +171,43 @@ pub(super) async fn transcribe(
     let mut debug_params = vec![];
 
     // Build the URL with model name in the path
-    let endpoint = format!("{}/{}", config.endpoint(), config.model_id);
+    let endpoint = format!("{}/{}", config.endpoint, config.model_id);
 
-    // Add keywords as prompt for better transcription context (similar to OpenAI)
-    if !config.keywords.is_empty() {
-        let prompt = config.keywords.join(", ");
-        form = form.text("prompt", prompt.clone());
-        debug_params.push(format!("prompt={prompt}"));
-        tracing::debug!(
-            "Keywords used as prompt for DeepInfra model: {:?}",
-            config.keywords
-        );
+    if let Some(language) = config.option_string("language") {
+        if !language.is_empty() {
+            form = form.text("language", language.to_string());
+            debug_params.push(format!("language={language}"));
+        }
+    }
+
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+        debug_params.push(format!("temperature={temperature}"));
+    }
+
+    if let Some(task) = config.option_string("task") {
+        form = form.text("task", task.to_string());
+        debug_params.push(format!("task={task}"));
+    }
+
+    let initial_prompt = config
+        .option_string("initial_prompt")
+        .map(ToString::to_string)
+        .or_else(|| (!config.keywords.is_empty()).then(|| config.keywords.join(", ")));
+    if let Some(initial_prompt) = initial_prompt {
+        form = form.text("initial_prompt", initial_prompt.clone());
+        debug_params.push(format!("initial_prompt={initial_prompt}"));
+        tracing::debug!("Initial prompt used for DeepInfra model: {initial_prompt}");
+    }
+
+    if let Some(chunk_level) = config.option_string("chunk_level") {
+        form = form.text("chunk_level", chunk_level.to_string());
+        debug_params.push(format!("chunk_level={chunk_level}"));
+    }
+
+    if let Some(chunk_length_s) = config.option_integer("chunk_length_s") {
+        form = form.text("chunk_length_s", chunk_length_s.to_string());
+        debug_params.push(format!("chunk_length_s={chunk_length_s}"));
     }
 
     tracing::debug!(

--- a/src/transcription/api/elevenlabs.rs
+++ b/src/transcription/api/elevenlabs.rs
@@ -7,6 +7,225 @@ use serde::Deserialize;
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "elevenlabs",
+        model_id: "scribe_v2",
+        endpoint: "https://api.elevenlabs.io/v1/speech-to-text",
+        display_name: "Scribe v2 (highest accuracy, 99 languages)",
+        description: "ElevenLabs' latest Scribe speech-to-text model for high-accuracy transcription with broad multilingual support, including support for many languages beyond English.",
+        languages: &["Multilingual", "99 languages"],
+    },
+    ModelSpec {
+        provider_id: "elevenlabs",
+        model_id: "scribe_v1",
+        endpoint: "https://api.elevenlabs.io/v1/speech-to-text",
+        display_name: "Scribe v1 (previous generation)",
+        description: "ElevenLabs' previous-generation Scribe speech-to-text model for multilingual transcription workloads.",
+        languages: &["Multilingual", "99 languages"],
+    },
+];
+
+const SCRIBE_V1_OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language_code",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "tag_audio_events",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "timestamps_granularity",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "diarize",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "num_speakers",
+        kind: ModelOptionKind::Integer,
+    },
+    ModelOptionSpec {
+        name: "diarization_threshold",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "file_format",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "seed",
+        kind: ModelOptionKind::Integer,
+    },
+    ModelOptionSpec {
+        name: "use_multi_channel",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "keyterms",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+const SCRIBE_V2_OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language_code",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "tag_audio_events",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "timestamps_granularity",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "diarize",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "detect_speaker_roles",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "num_speakers",
+        kind: ModelOptionKind::Integer,
+    },
+    ModelOptionSpec {
+        name: "diarization_threshold",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "file_format",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "seed",
+        kind: ModelOptionKind::Integer,
+    },
+    ModelOptionSpec {
+        name: "use_multi_channel",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "keyterms",
+        kind: ModelOptionKind::StringList,
+    },
+    ModelOptionSpec {
+        name: "no_verbatim",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "entity_detection",
+        kind: ModelOptionKind::StringOrStringList,
+    },
+    ModelOptionSpec {
+        name: "entity_redaction",
+        kind: ModelOptionKind::StringOrStringList,
+    },
+    ModelOptionSpec {
+        name: "entity_redaction_mode",
+        kind: ModelOptionKind::String,
+    },
+];
+
+pub(super) fn option_schema(model_id: &str) -> Option<ModelOptionSchema> {
+    match model_id {
+        "scribe_v2" => Some(ModelOptionSchema::new(SCRIBE_V2_OPTIONS)),
+        "scribe_v1" => Some(ModelOptionSchema::new(SCRIBE_V1_OPTIONS)),
+        _ => None,
+    }
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "diarization_threshold", 0.1..=0.4)?;
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=2.0)?;
+    super::validate_integer_range(full_model_id, options, "num_speakers", 1..=32)?;
+    super::validate_integer_range(full_model_id, options, "seed", 0..=2_147_483_647)?;
+
+    if let Some(value) = options.get("timestamps_granularity") {
+        super::validate_string_value(
+            full_model_id,
+            "timestamps_granularity",
+            value,
+            &["none", "word", "character"],
+        )?;
+    }
+
+    if let Some(value) = options.get("file_format") {
+        super::validate_string_value(
+            full_model_id,
+            "file_format",
+            value,
+            &["pcm_s16le_16", "other"],
+        )?;
+    }
+
+    if let Some(value) = options.get("entity_redaction_mode") {
+        super::validate_string_value(
+            full_model_id,
+            "entity_redaction_mode",
+            value,
+            &["redacted", "entity_type", "enumerated_entity_type"],
+        )?;
+    }
+
+    if options.contains_key("diarization_threshold") {
+        if matches!(options.get("diarize"), Some(ModelOptionValue::Bool(false))) {
+            anyhow::bail!(
+                "Invalid options for '{}'. ElevenLabs diarization_threshold requires diarize = true.",
+                full_model_id
+            );
+        }
+        if options.contains_key("num_speakers") {
+            anyhow::bail!(
+                "Invalid options for '{}'. ElevenLabs diarization_threshold cannot be used with num_speakers.",
+                full_model_id
+            );
+        }
+    }
+
+    if matches!(
+        options.get("detect_speaker_roles"),
+        Some(ModelOptionValue::Bool(true))
+    ) {
+        if !matches!(options.get("diarize"), Some(ModelOptionValue::Bool(true))) {
+            anyhow::bail!(
+                "Invalid options for '{}'. ElevenLabs detect_speaker_roles requires diarize = true.",
+                full_model_id
+            );
+        }
+        if matches!(
+            options.get("use_multi_channel"),
+            Some(ModelOptionValue::Bool(true))
+        ) {
+            anyhow::bail!(
+                "Invalid options for '{}'. ElevenLabs detect_speaker_roles cannot be used with use_multi_channel = true.",
+                full_model_id
+            );
+        }
+    }
+
+    Ok(())
+}
 
 /// ElevenLabs speech-to-text response structure
 #[derive(Debug, Deserialize)]
@@ -42,22 +261,63 @@ pub(super) async fn transcribe(
         .text("model_id", config.model_id.clone())
         .part("file", file_part);
 
-    // Add optional language code from provider config
-    let elevenlabs_config = &config.providers.elevenlabs;
-    if let Some(ref lang) = elevenlabs_config.language_code {
-        if !lang.is_empty() {
-            form = form.text("language_code", lang.clone());
+    if let Some(language_code) = config.option_string("language_code") {
+        if !language_code.is_empty() {
+            form = form.text("language_code", language_code.to_string());
+        }
+    }
+    if let Some(tag_audio_events) = config.option_bool("tag_audio_events") {
+        form = form.text("tag_audio_events", tag_audio_events.to_string());
+    }
+    if let Some(timestamps_granularity) = config.option_string("timestamps_granularity") {
+        form = form.text("timestamps_granularity", timestamps_granularity.to_string());
+    }
+    if let Some(diarize) = config.option_bool("diarize") {
+        form = form.text("diarize", diarize.to_string());
+    }
+    if let Some(detect_speaker_roles) = config.option_bool("detect_speaker_roles") {
+        form = form.text("detect_speaker_roles", detect_speaker_roles.to_string());
+    }
+    if let Some(num_speakers) = config.option_integer("num_speakers") {
+        form = form.text("num_speakers", num_speakers.to_string());
+    }
+    if let Some(diarization_threshold) = config.option_number("diarization_threshold") {
+        form = form.text("diarization_threshold", diarization_threshold.to_string());
+    }
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+    }
+    if let Some(file_format) = config.option_string("file_format") {
+        form = form.text("file_format", file_format.to_string());
+    }
+    if let Some(seed) = config.option_integer("seed") {
+        form = form.text("seed", seed.to_string());
+    }
+    if let Some(use_multi_channel) = config.option_bool("use_multi_channel") {
+        form = form.text("use_multi_channel", use_multi_channel.to_string());
+    }
+    if let Some(no_verbatim) = config.option_bool("no_verbatim") {
+        form = form.text("no_verbatim", no_verbatim.to_string());
+    }
+    form = add_string_or_string_list_fields(form, config, "entity_detection");
+    form = add_string_or_string_list_fields(form, config, "entity_redaction");
+    if let Some(entity_redaction_mode) = config.option_string("entity_redaction_mode") {
+        form = form.text("entity_redaction_mode", entity_redaction_mode.to_string());
+    }
+
+    if let Some(keyterms) = config.option_string_list("keyterms") {
+        for keyterm in keyterms {
+            form = form.text("keyterms", keyterm.clone());
+        }
+    } else {
+        // Each keyterm is passed as a separate form field.
+        for keyword in &config.keywords {
+            form = form.text("keyterms", keyword.clone());
         }
     }
 
-    // Add keyterms (ElevenLabs supports up to 1000 keyterms for boosting accuracy)
-    // Each keyterm is passed as a separate form field
-    for keyword in &config.keywords {
-        form = form.text("keyterms", keyword.clone());
-    }
-
     let client = reqwest::Client::new();
-    let url = config.endpoint();
+    let url = config.endpoint;
 
     tracing::debug!(
         "ElevenLabs API Call:\n  URL: {}\n  Method: POST\n  Model: {}\n  Keyterms: {:?}",
@@ -114,4 +374,22 @@ pub(super) async fn transcribe(
         .map_err(|e| anyhow::anyhow!("Failed to parse ElevenLabs response: {e}"))?;
 
     Ok(elevenlabs_response.text.trim().to_string())
+}
+
+fn add_string_or_string_list_fields(
+    mut form: reqwest::multipart::Form,
+    config: &TranscriptionConfig,
+    name: &'static str,
+) -> reqwest::multipart::Form {
+    match config.model_options.get(name) {
+        Some(ModelOptionValue::String(value)) => form = form.text(name, value.clone()),
+        Some(ModelOptionValue::StringList(values)) => {
+            for value in values {
+                form = form.text(name, value.clone());
+            }
+        }
+        _ => {}
+    }
+
+    form
 }

--- a/src/transcription/api/groq.rs
+++ b/src/transcription/api/groq.rs
@@ -6,6 +6,90 @@ use serde::Deserialize;
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "groq",
+        model_id: "whisper-large-v3",
+        endpoint: "https://api.groq.com/openai/v1/audio/transcriptions",
+        display_name: "Whisper Large V3 (high accuracy)",
+        description: "Groq-hosted Whisper Large V3 for error-sensitive multilingual transcription and translation. Groq documents this option as the higher-accuracy choice among its Whisper models.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "groq",
+        model_id: "whisper-large-v3-turbo",
+        endpoint: "https://api.groq.com/openai/v1/audio/transcriptions",
+        display_name: "Whisper Large V3 Turbo (fastest)",
+        description: "Groq-hosted Whisper Large V3 Turbo, a fine-tuned and pruned Large V3 variant designed for fast multilingual transcription with strong price/performance tradeoffs.",
+        languages: &["Multilingual"],
+    },
+];
+
+const OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "response_format",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "timestamp_granularities",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+pub(super) fn option_schema(_model_id: &str) -> Option<ModelOptionSchema> {
+    Some(ModelOptionSchema::new(OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    if let Some(value) = options.get("response_format") {
+        super::validate_string_value(
+            full_model_id,
+            "response_format",
+            value,
+            &["json", "verbose_json"],
+        )?;
+    }
+
+    if let Some(value) = options.get("timestamp_granularities") {
+        super::validate_string_list_values(
+            full_model_id,
+            "timestamp_granularities",
+            value,
+            &["word", "segment"],
+        )?;
+        if let Some(ModelOptionValue::String(response_format)) = options.get("response_format") {
+            if response_format != "verbose_json" {
+                anyhow::bail!(
+                    "Invalid options for '{}'. Groq timestamp_granularities requires response_format = \"verbose_json\".",
+                    full_model_id
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
 
 /// Groq API response wrapper
 #[derive(Debug, Deserialize)]
@@ -46,18 +130,41 @@ pub(super) async fn transcribe(
     // Debug log: Log the API call details (without the audio data)
     let mut debug_params = vec![format!("model={}", config.model_id)];
 
-    // Add keywords as prompt for better transcription context
-    if !config.keywords.is_empty() {
-        let prompt = config.keywords.join(", ");
-        form = form.text("prompt", prompt.clone());
-        debug_params.push(format!("prompt={prompt}"));
-        tracing::debug!(
-            "Keywords used as prompt for Groq model: {:?}",
-            config.keywords
-        );
+    if let Some(language) = config.option_string("language") {
+        if !language.is_empty() {
+            form = form.text("language", language.to_string());
+            debug_params.push(format!("language={language}"));
+        }
     }
 
-    let endpoint = config.endpoint();
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+        debug_params.push(format!("temperature={temperature}"));
+    }
+
+    let prompt = config
+        .option_string("prompt")
+        .map(ToString::to_string)
+        .or_else(|| (!config.keywords.is_empty()).then(|| config.keywords.join(", ")));
+    if let Some(prompt) = prompt {
+        form = form.text("prompt", prompt.clone());
+        debug_params.push(format!("prompt={prompt}"));
+        tracing::debug!("Prompt used for Groq model: {prompt}");
+    }
+
+    if let Some(response_format) = response_format(config) {
+        form = form.text("response_format", response_format.to_string());
+        debug_params.push(format!("response_format={response_format}"));
+    }
+
+    if let Some(granularities) = config.option_string_list("timestamp_granularities") {
+        for granularity in granularities {
+            form = form.text("timestamp_granularities[]", granularity.clone());
+            debug_params.push(format!("timestamp_granularities[]={granularity}"));
+        }
+    }
+
+    let endpoint = config.endpoint;
 
     tracing::debug!(
         "Groq API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",
@@ -118,4 +225,19 @@ pub(super) async fn transcribe(
     );
 
     Ok(groq_response.text.trim().to_string())
+}
+
+fn response_format(config: &TranscriptionConfig) -> Option<&str> {
+    if let Some(response_format) = config.option_string("response_format") {
+        return Some(response_format);
+    }
+
+    if config
+        .option_string_list("timestamp_granularities")
+        .is_some_and(|granularities| !granularities.is_empty())
+    {
+        return Some("verbose_json");
+    }
+
+    Some("json")
 }

--- a/src/transcription/api/local.rs
+++ b/src/transcription/api/local.rs
@@ -1,9 +1,14 @@
 use std::path::Path;
 
 use super::TranscriptionConfig;
-use crate::config::ModelOptionValue;
-use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec};
+use crate::config::{LocalTranscriptionConfig, ModelOptionValue};
+use crate::transcription::{
+    daemon_client::{probe_daemon, request_transcription},
+    local_models::{resolve_installed_model_path, ModelError},
+    model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec},
+};
 use indexmap::IndexMap;
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
 const OPTIONS: &[ModelOptionSpec] = &[
     ModelOptionSpec {
@@ -46,10 +51,6 @@ pub(super) fn validate_options(
 
     Ok(())
 }
-use crate::config::LocalTranscriptionConfig;
-use crate::transcription::daemon_client::{probe_daemon, request_transcription};
-use crate::transcription::local_models::{resolve_installed_model_path, ModelError};
-use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
 pub(super) async fn transcribe(
     config: &TranscriptionConfig,

--- a/src/transcription/api/local.rs
+++ b/src/transcription/api/local.rs
@@ -1,6 +1,51 @@
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec};
+use indexmap::IndexMap;
+
+const OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "entropy_thold",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "no_context",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "no_speech_thold",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "no_timestamps",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+];
+
+pub(super) fn option_schema(model_id: &str) -> Option<ModelOptionSchema> {
+    (!model_id.is_empty()).then(|| ModelOptionSchema::new(OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_min(full_model_id, options, "entropy_thold", 0.0)?;
+    super::validate_number_range(full_model_id, options, "no_speech_thold", 0.0..=1.0)?;
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    Ok(())
+}
 use crate::config::LocalTranscriptionConfig;
 use crate::transcription::daemon_client::{probe_daemon, request_transcription};
 use crate::transcription::local_models::{resolve_installed_model_path, ModelError};
@@ -11,7 +56,8 @@ pub(super) async fn transcribe(
     audio_path: &Path,
 ) -> anyhow::Result<String> {
     validate_local_audio_format(audio_path)?;
-    let local_config = config.local_config().cloned().unwrap_or_default();
+    let mut local_config = config.local_config().cloned().unwrap_or_default();
+    apply_model_options(config, &mut local_config);
 
     if let Some(text) = try_daemon_transcription(&config.model_id, audio_path, &local_config).await
     {
@@ -75,6 +121,27 @@ pub(super) async fn transcribe(
     .map_err(|err| anyhow::anyhow!("Local whisper runtime task failed: {err}"))??;
 
     Ok(filter_obvious_hallucination(&text).unwrap_or_default())
+}
+
+fn apply_model_options(config: &TranscriptionConfig, local_config: &mut LocalTranscriptionConfig) {
+    if let Some(language) = config.option_string("language") {
+        local_config.language = language.to_string();
+    }
+    if let Some(no_timestamps) = config.option_bool("no_timestamps") {
+        local_config.no_timestamps = no_timestamps;
+    }
+    if let Some(no_context) = config.option_bool("no_context") {
+        local_config.no_context = no_context;
+    }
+    if let Some(temperature) = config.option_number("temperature") {
+        local_config.temperature = temperature as f32;
+    }
+    if let Some(entropy_thold) = config.option_number("entropy_thold") {
+        local_config.entropy_thold = entropy_thold as f32;
+    }
+    if let Some(no_speech_thold) = config.option_number("no_speech_thold") {
+        local_config.no_speech_thold = no_speech_thold as f32;
+    }
 }
 
 async fn try_daemon_transcription(

--- a/src/transcription/api/local.rs
+++ b/src/transcription/api/local.rs
@@ -241,3 +241,20 @@ pub(crate) fn validate_local_audio_format(audio_path: &Path) -> anyhow::Result<(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_schema_is_shared_by_local_whisper_models() {
+        let schema = option_schema("turbo").unwrap();
+
+        assert!(schema.option("language").is_some());
+        assert!(schema.option("temperature").is_some());
+        assert!(schema.option("entropy_thold").is_some());
+        assert!(schema.option("no_speech_thold").is_some());
+        assert!(schema.option("no_context").is_some());
+        assert!(schema.option("no_timestamps").is_some());
+    }
+}

--- a/src/transcription/api/mistral.rs
+++ b/src/transcription/api/mistral.rs
@@ -7,6 +7,80 @@ use serde::Deserialize;
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "mistral",
+        model_id: "voxtral-mini-latest",
+        endpoint: "https://api.mistral.ai/v1/audio/transcriptions",
+        display_name: "Voxtral Mini Transcribe (fast, efficient, 13 languages)",
+        description: "Mistral's Voxtral Mini transcription model for fast, efficient multilingual speech-to-text via the Mistral API.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "mistral",
+        model_id: "voxtral-mini-2602",
+        endpoint: "https://api.mistral.ai/v1/audio/transcriptions",
+        display_name: "Voxtral Mini 2602 (newer version, improved accuracy)",
+        description: "Pinned Voxtral Mini 2602 transcription model for stable Mistral speech-to-text behavior.",
+        languages: &["Multilingual"],
+    },
+];
+
+const OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "diarize",
+        kind: ModelOptionKind::Bool,
+    },
+    ModelOptionSpec {
+        name: "context_bias",
+        kind: ModelOptionKind::StringList,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "timestamp_granularities",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+pub(super) fn option_schema(_model_id: &str) -> Option<ModelOptionSchema> {
+    Some(ModelOptionSchema::new(OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    if let Some(value) = options.get("timestamp_granularities") {
+        super::validate_string_list_values(
+            full_model_id,
+            "timestamp_granularities",
+            value,
+            &["segment", "word"],
+        )?;
+    }
+
+    if options.contains_key("language") && options.contains_key("timestamp_granularities") {
+        anyhow::bail!(
+            "Invalid options for '{}'. Mistral timestamp_granularities is not compatible with language.",
+            full_model_id
+        );
+    }
+
+    Ok(())
+}
 
 /// Mistral API response wrapper
 #[derive(Debug, Deserialize)]
@@ -42,11 +116,36 @@ pub(super) async fn transcribe(
         .text("model", config.model_id.clone());
 
     // Debug log: Log the API call details (without the audio data)
-    let debug_params = [format!("model={}", config.model_id)];
+    let mut debug_params = vec![format!("model={}", config.model_id)];
 
-    // Add keywords as context_bias for better transcription accuracy
-    // Mistral supports up to 100 words/phrases for context biasing
-    if !config.keywords.is_empty() {
+    if let Some(language) = config.option_string("language") {
+        form = form.text("language", language.to_string());
+        debug_params.push(format!("language={language}"));
+    }
+
+    if let Some(diarize) = config.option_bool("diarize") {
+        form = form.text("diarize", diarize.to_string());
+        debug_params.push(format!("diarize={diarize}"));
+    }
+
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+        debug_params.push(format!("temperature={temperature}"));
+    }
+
+    if let Some(granularities) = config.option_string_list("timestamp_granularities") {
+        for granularity in granularities {
+            form = form.text("timestamp_granularities", granularity.clone());
+            debug_params.push(format!("timestamp_granularities={granularity}"));
+        }
+    }
+
+    if let Some(context_bias) = config.option_string_list("context_bias") {
+        for value in context_bias {
+            form = form.text("context_bias", value.clone());
+            debug_params.push(format!("context_bias={value}"));
+        }
+    } else if !config.keywords.is_empty() {
         for keyword in &config.keywords {
             form = form.text("context_bias", keyword.clone());
         }
@@ -56,16 +155,7 @@ pub(super) async fn transcribe(
         );
     }
 
-    // Add optional language parameter from provider config
-    let mistral_config = &config.providers.mistral;
-    if let Some(ref lang) = mistral_config.language {
-        if !lang.is_empty() {
-            form = form.text("language", lang.clone());
-            tracing::debug!("Language set for Mistral model: {}", lang);
-        }
-    }
-
-    let endpoint = config.endpoint();
+    let endpoint = config.endpoint;
 
     let client = reqwest::Client::new();
 

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -17,8 +17,11 @@ mod openai;
 use serde::Deserialize;
 use std::path::Path;
 
+use super::model::{ModelOptionSchema, ModelSpec};
 use super::provider::TranscriptionProvider;
-use crate::config::file::{LocalTranscriptionConfig, ProvidersConfig};
+use crate::config::file::{LocalTranscriptionConfig, ModelOptionValue, ProvidersConfig};
+use indexmap::IndexMap;
+use std::ops::RangeInclusive;
 
 /// Configuration for transcription requests
 #[derive(Debug, Clone)]
@@ -27,12 +30,16 @@ pub struct TranscriptionConfig {
     pub provider: TranscriptionProvider,
     /// The selected model ID, including data-driven local model IDs
     pub model_id: String,
+    /// Base API endpoint for the selected model
+    pub endpoint: &'static str,
     /// The API key for authentication
     pub api_key: String,
     /// Keywords to improve transcription accuracy
     pub keywords: Vec<String>,
     /// Provider-specific configurations
     pub providers: ProvidersConfig,
+    /// Validated request options for the selected model
+    pub model_options: IndexMap<String, ModelOptionValue>,
 }
 
 impl TranscriptionConfig {
@@ -40,41 +47,38 @@ impl TranscriptionConfig {
     pub fn new_cloud(
         provider: TranscriptionProvider,
         model_id: String,
+        endpoint: &'static str,
         api_key: String,
         keywords: Vec<String>,
         providers: ProvidersConfig,
+        model_options: IndexMap<String, ModelOptionValue>,
     ) -> Self {
         Self {
             provider,
             model_id,
+            endpoint,
             api_key,
             keywords,
             providers,
+            model_options,
         }
     }
 
     /// Creates a local transcription configuration with a registry-backed model ID.
-    pub fn new_local(model_id: String, keywords: Vec<String>, providers: ProvidersConfig) -> Self {
+    pub fn new_local(
+        model_id: String,
+        keywords: Vec<String>,
+        providers: ProvidersConfig,
+        model_options: IndexMap<String, ModelOptionValue>,
+    ) -> Self {
         Self {
             provider: TranscriptionProvider::Local,
             model_id,
+            endpoint: "",
             api_key: String::new(),
             keywords,
             providers,
-        }
-    }
-
-    pub fn endpoint(&self) -> &'static str {
-        match self.provider {
-            TranscriptionProvider::OpenAI => "https://api.openai.com/v1/audio/transcriptions",
-            TranscriptionProvider::Deepgram => "https://api.deepgram.com/v1/listen",
-            TranscriptionProvider::DeepInfra => "https://api.deepinfra.com/v1/inference",
-            TranscriptionProvider::Groq => "https://api.groq.com/openai/v1/audio/transcriptions",
-            TranscriptionProvider::AssemblyAI => "https://api.assemblyai.com/v2",
-            TranscriptionProvider::Berget => "https://api.berget.ai/v1/audio/transcriptions",
-            TranscriptionProvider::ElevenLabs => "https://api.elevenlabs.io/v1/speech-to-text",
-            TranscriptionProvider::Mistral => "https://api.mistral.ai/v1/audio/transcriptions",
-            TranscriptionProvider::Local => "",
+            model_options,
         }
     }
 
@@ -84,6 +88,42 @@ impl TranscriptionConfig {
             Some(&self.providers.local)
         } else {
             None
+        }
+    }
+
+    pub fn option_bool(&self, name: &str) -> Option<bool> {
+        match self.model_options.get(name) {
+            Some(ModelOptionValue::Bool(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    pub fn option_string(&self, name: &str) -> Option<&str> {
+        match self.model_options.get(name) {
+            Some(ModelOptionValue::String(value)) => Some(value),
+            _ => None,
+        }
+    }
+
+    pub fn option_number(&self, name: &str) -> Option<f64> {
+        match self.model_options.get(name) {
+            Some(ModelOptionValue::Number(value)) => Some(*value),
+            Some(ModelOptionValue::Integer(value)) => Some(*value as f64),
+            _ => None,
+        }
+    }
+
+    pub fn option_integer(&self, name: &str) -> Option<i64> {
+        match self.model_options.get(name) {
+            Some(ModelOptionValue::Integer(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    pub fn option_string_list(&self, name: &str) -> Option<&[String]> {
+        match self.model_options.get(name) {
+            Some(ModelOptionValue::StringList(value)) => Some(value),
+            _ => None,
         }
     }
 }
@@ -125,4 +165,169 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
     }?;
 
     Ok(result)
+}
+
+pub(crate) fn option_schema(provider_id: &str, model_id: &str) -> Option<ModelOptionSchema> {
+    match provider_id {
+        "openai" => openai::option_schema(model_id),
+        "deepgram" => deepgram::option_schema(model_id),
+        "deepinfra" => deepinfra::option_schema(model_id),
+        "groq" => groq::option_schema(model_id),
+        "assemblyai" => assemblyai::option_schema(model_id),
+        "berget" => berget::option_schema(model_id),
+        "elevenlabs" => elevenlabs::option_schema(model_id),
+        "mistral" => mistral::option_schema(model_id),
+        "local" => local::option_schema(model_id),
+        _ => None,
+    }
+}
+
+pub(crate) fn validate_model_options(
+    provider_id: &str,
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    match provider_id {
+        "openai" => openai::validate_options(full_model_id, options),
+        "groq" => groq::validate_options(full_model_id, options),
+        "deepinfra" => deepinfra::validate_options(full_model_id, options),
+        "assemblyai" => assemblyai::validate_options(full_model_id, options),
+        "berget" => berget::validate_options(full_model_id, options),
+        "elevenlabs" => elevenlabs::validate_options(full_model_id, options),
+        "mistral" => mistral::validate_options(full_model_id, options),
+        "local" => local::validate_options(full_model_id, options),
+        _ => Ok(()),
+    }
+}
+
+pub(super) fn validate_string_value(
+    full_model_id: &str,
+    option_name: &str,
+    value: &ModelOptionValue,
+    allowed: &[&str],
+) -> anyhow::Result<()> {
+    let ModelOptionValue::String(value) = value else {
+        return Ok(());
+    };
+
+    if !allowed.contains(&value.as_str()) {
+        anyhow::bail!(
+            "Invalid value for option '{}' in '{}'. Expected one of: {}.",
+            option_name,
+            full_model_id,
+            allowed.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_string_list_values(
+    full_model_id: &str,
+    option_name: &str,
+    value: &ModelOptionValue,
+    allowed: &[&str],
+) -> anyhow::Result<()> {
+    let ModelOptionValue::StringList(values) = value else {
+        return Ok(());
+    };
+
+    for value in values {
+        if !allowed.contains(&value.as_str()) {
+            anyhow::bail!(
+                "Invalid value for option '{}' in '{}'. Expected one of: {}.",
+                option_name,
+                full_model_id,
+                allowed.join(", ")
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_integer_range(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+    option_name: &str,
+    range: RangeInclusive<i64>,
+) -> anyhow::Result<()> {
+    if let Some(ModelOptionValue::Integer(value)) = options.get(option_name) {
+        if !range.contains(value) {
+            anyhow::bail!(
+                "Invalid value for option '{}' in '{}'. Expected {}-{}.",
+                option_name,
+                full_model_id,
+                range.start(),
+                range.end()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_number_range(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+    option_name: &str,
+    range: RangeInclusive<f64>,
+) -> anyhow::Result<()> {
+    let value = match options.get(option_name) {
+        Some(ModelOptionValue::Number(value)) => *value,
+        Some(ModelOptionValue::Integer(value)) => *value as f64,
+        _ => return Ok(()),
+    };
+
+    if !range.contains(&value) {
+        anyhow::bail!(
+            "Invalid value for option '{}' in '{}'. Expected {}-{}.",
+            option_name,
+            full_model_id,
+            range.start(),
+            range.end()
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_number_min(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+    option_name: &str,
+    min: f64,
+) -> anyhow::Result<()> {
+    let value = match options.get(option_name) {
+        Some(ModelOptionValue::Number(value)) => *value,
+        Some(ModelOptionValue::Integer(value)) => *value as f64,
+        _ => return Ok(()),
+    };
+
+    if value < min {
+        anyhow::bail!(
+            "Invalid value for option '{}' in '{}'. Expected >= {}.",
+            option_name,
+            full_model_id,
+            min
+        );
+    }
+
+    Ok(())
+}
+
+pub(crate) fn all_models() -> Vec<&'static ModelSpec> {
+    [
+        openai::MODELS,
+        deepgram::MODELS,
+        groq::MODELS,
+        deepinfra::MODELS,
+        assemblyai::MODELS,
+        berget::MODELS,
+        elevenlabs::MODELS,
+        mistral::MODELS,
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }

--- a/src/transcription/api/openai.rs
+++ b/src/transcription/api/openai.rs
@@ -6,6 +6,174 @@ use serde::Deserialize;
 use std::path::Path;
 
 use super::TranscriptionConfig;
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec, ModelSpec};
+use indexmap::IndexMap;
+
+pub(super) const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        provider_id: "openai",
+        model_id: "gpt-4o-transcribe",
+        endpoint: "https://api.openai.com/v1/audio/transcriptions",
+        display_name: "GPT-4o Transcribe (latest, best accuracy)",
+        description: "OpenAI's higher-quality speech-to-text model for transcribing audio in the source language. Supports prompting for domain terms, names, and preferred writing style.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "openai",
+        model_id: "gpt-4o-mini-transcribe",
+        endpoint: "https://api.openai.com/v1/audio/transcriptions",
+        display_name: "GPT-4o Mini Transcribe (faster, lighter)",
+        description: "OpenAI's smaller GPT-4o transcription model, intended for faster and lower-cost speech-to-text while retaining support for prompts and plain text or JSON output.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "openai",
+        model_id: "gpt-4o-transcribe-diarize",
+        endpoint: "https://api.openai.com/v1/audio/transcriptions",
+        display_name: "GPT-4o Transcribe Diarize",
+        description: "OpenAI's GPT-4o transcription model for diarized JSON output with speaker-segment annotations.",
+        languages: &["Multilingual"],
+    },
+    ModelSpec {
+        provider_id: "openai",
+        model_id: "whisper-1",
+        endpoint: "https://api.openai.com/v1/audio/transcriptions",
+        display_name: "Whisper (legacy)",
+        description: "OpenAI's hosted Whisper model. Supports transcription in the source language, translation to English, verbose JSON, SRT/VTT output, and segment or word timestamps.",
+        languages: &["Multilingual", "translation to English"],
+    },
+];
+
+const GPT_4O_OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "include",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+const DIARIZE_OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "response_format",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "chunking_strategy",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "known_speaker_names",
+        kind: ModelOptionKind::StringList,
+    },
+    ModelOptionSpec {
+        name: "known_speaker_references",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+const WHISPER_OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "response_format",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "timestamp_granularities",
+        kind: ModelOptionKind::StringList,
+    },
+];
+
+pub(super) fn option_schema(model_id: &str) -> Option<ModelOptionSchema> {
+    match model_id {
+        "gpt-4o-transcribe" | "gpt-4o-mini-transcribe" => {
+            Some(ModelOptionSchema::new(GPT_4O_OPTIONS))
+        }
+        "gpt-4o-transcribe-diarize" => Some(ModelOptionSchema::new(DIARIZE_OPTIONS)),
+        "whisper-1" => Some(ModelOptionSchema::new(WHISPER_OPTIONS)),
+        _ => None,
+    }
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+
+    if let Some(value) = options.get("include") {
+        super::validate_string_list_values(full_model_id, "include", value, &["logprobs"])?;
+    }
+
+    if let Some(value) = options.get("timestamp_granularities") {
+        super::validate_string_list_values(
+            full_model_id,
+            "timestamp_granularities",
+            value,
+            &["word", "segment"],
+        )?;
+    }
+
+    if let Some(value) = options.get("chunking_strategy") {
+        super::validate_string_value(full_model_id, "chunking_strategy", value, &["auto"])?;
+    }
+
+    if let Some(value) = options.get("response_format") {
+        let allowed = if full_model_id == "openai/gpt-4o-transcribe-diarize" {
+            &["json", "diarized_json"][..]
+        } else {
+            &["json", "verbose_json"][..]
+        };
+        super::validate_string_value(full_model_id, "response_format", value, allowed)?;
+    }
+
+    if full_model_id == "openai/whisper-1" && options.contains_key("timestamp_granularities") {
+        if let Some(ModelOptionValue::String(response_format)) = options.get("response_format") {
+            if response_format != "verbose_json" {
+                anyhow::bail!(
+                    "Invalid options for '{}'. OpenAI timestamp_granularities requires response_format = \"verbose_json\".",
+                    full_model_id
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
 
 /// OpenAI API response wrapper
 #[derive(Debug, Deserialize)]
@@ -46,34 +214,66 @@ pub(super) async fn transcribe(
     // Debug log: Log the API call details (without the audio data)
     let mut debug_params = vec![format!("model={}", config.model_id)];
 
-    // Add keywords as prompt for better transcription context
-    // Note: gpt-4o-transcribe doesn't support prompt parameter, only whisper-1 and gpt-4o-mini-transcribe do
-    if !config.keywords.is_empty() {
-        let should_use_prompt = match config.model_id.as_str() {
-            "gpt-4o-transcribe" => false, // gpt-4o-transcribe doesn't support prompt
-            _ => true,                    // whisper-1 and gpt-4o-mini-transcribe support it
-        };
-
-        if should_use_prompt {
-            let prompt = config.keywords.join(", ");
-            form = form.text("prompt", prompt.clone());
-            debug_params.push(format!("prompt={prompt}"));
-            tracing::debug!(
-                "Keywords used as prompt for OpenAI model: {:?}",
-                config.keywords
-            );
-        } else {
-            tracing::debug!(
-                "Keywords defined but {} does not support prompt parameter. Keywords: {:?}",
-                config.model_id,
-                config.keywords
-            );
+    if let Some(language) = config.option_string("language") {
+        if !language.is_empty() {
+            form = form.text("language", language.to_string());
+            debug_params.push(format!("language={language}"));
         }
     }
 
-    let endpoint = config.endpoint();
-    let url = format!("{endpoint}?response_format=json");
-    debug_params.push("response_format=json".to_string());
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+        debug_params.push(format!("temperature={temperature}"));
+    }
+
+    let prompt = config
+        .option_string("prompt")
+        .map(ToString::to_string)
+        .or_else(|| (!config.keywords.is_empty()).then(|| config.keywords.join(", ")));
+    if let Some(prompt) = prompt {
+        form = form.text("prompt", prompt.clone());
+        debug_params.push(format!("prompt={prompt}"));
+        tracing::debug!("Prompt used for OpenAI model: {prompt}");
+    }
+
+    if let Some(response_format) = response_format(config) {
+        form = form.text("response_format", response_format.to_string());
+        debug_params.push(format!("response_format={response_format}"));
+    }
+
+    if let Some(include) = config.option_string_list("include") {
+        form = add_string_list(form, &mut debug_params, "include[]", include);
+    }
+
+    if let Some(granularities) = config.option_string_list("timestamp_granularities") {
+        form = add_string_list(
+            form,
+            &mut debug_params,
+            "timestamp_granularities[]",
+            granularities,
+        );
+    }
+
+    if let Some(chunking_strategy) = config.option_string("chunking_strategy") {
+        form = form.text("chunking_strategy", chunking_strategy.to_string());
+        debug_params.push(format!("chunking_strategy={chunking_strategy}"));
+    }
+
+    if let Some(names) = config.option_string_list("known_speaker_names") {
+        form = add_string_list(form, &mut debug_params, "known_speaker_names[]", names);
+    }
+
+    if let Some(references) = config.option_string_list("known_speaker_references") {
+        form = add_string_list(
+            form,
+            &mut debug_params,
+            "known_speaker_references[]",
+            references,
+        );
+    }
+
+    let endpoint = config.endpoint;
+    let url = endpoint.to_string();
 
     tracing::debug!(
         "OpenAI API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",
@@ -137,4 +337,38 @@ pub(super) async fn transcribe(
     );
 
     Ok(transcription.text.trim().to_string())
+}
+
+fn response_format(config: &TranscriptionConfig) -> Option<&str> {
+    if let Some(response_format) = config.option_string("response_format") {
+        return Some(response_format);
+    }
+
+    if config.model_id == "gpt-4o-transcribe-diarize" {
+        return Some("diarized_json");
+    }
+
+    if config.model_id == "whisper-1"
+        && config
+            .option_string_list("timestamp_granularities")
+            .is_some_and(|granularities| !granularities.is_empty())
+    {
+        return Some("verbose_json");
+    }
+
+    Some("json")
+}
+
+fn add_string_list(
+    mut form: reqwest::multipart::Form,
+    debug_params: &mut Vec<String>,
+    field_name: &'static str,
+    values: &[String],
+) -> reqwest::multipart::Form {
+    for value in values {
+        form = form.text(field_name, value.clone());
+        debug_params.push(format!("{field_name}={value}"));
+    }
+
+    form
 }

--- a/src/transcription/context.rs
+++ b/src/transcription/context.rs
@@ -246,6 +246,33 @@ mod tests {
     }
 
     #[test]
+    fn model_option_overrides_parse_local_whisper_options() {
+        let model = selected_model("local", "turbo");
+        let options = parse_model_option_overrides(
+            &model,
+            &[
+                "language=sv".to_string(),
+                "no_context=false".to_string(),
+                "temperature=0.2".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            options.get("language"),
+            Some(&config::ModelOptionValue::String("sv".to_string()))
+        );
+        assert_eq!(
+            options.get("no_context"),
+            Some(&config::ModelOptionValue::Bool(false))
+        );
+        assert_eq!(
+            options.get("temperature"),
+            Some(&config::ModelOptionValue::Number(0.2))
+        );
+    }
+
+    #[test]
     fn model_option_overrides_parse_bool_or_string_list_bool() {
         let model = selected_model("deepgram", "nova-3");
         let options =

--- a/src/transcription/context.rs
+++ b/src/transcription/context.rs
@@ -1,4 +1,5 @@
 use crate::config::{self, OsttConfig, SelectedModel};
+use indexmap::IndexMap;
 
 use super::TranscriptionConfig;
 
@@ -11,11 +12,16 @@ pub(crate) struct TranscriptionContext {
 pub(crate) fn build_context(
     ostt_config: &OsttConfig,
     model_override: Option<SelectedModel>,
+    model_option_overrides: &[String],
 ) -> anyhow::Result<TranscriptionContext> {
     let selected_model = resolve_selected_model(ostt_config, model_override)?;
     let keywords = crate::keywords::load_keywords()?;
-    let transcription_config =
-        config_for_selected_model(ostt_config, &selected_model, keywords.clone())?;
+    let transcription_config = config_for_selected_model(
+        ostt_config,
+        &selected_model,
+        keywords.clone(),
+        model_option_overrides,
+    )?;
 
     Ok(TranscriptionContext {
         selected_model,
@@ -50,12 +56,219 @@ fn config_for_selected_model(
     ostt_config: &OsttConfig,
     selected_model: &SelectedModel,
     keywords: Vec<String>,
+    model_option_overrides: &[String],
 ) -> anyhow::Result<TranscriptionConfig> {
     let api_key = config::get_api_key(&selected_model.provider_id)?;
+    let full_model_id = format!("{}/{}", selected_model.provider_id, selected_model.model_id);
+    let mut model_options = ostt_config
+        .model_options
+        .get(&full_model_id)
+        .cloned()
+        .unwrap_or_default();
+    model_options.extend(parse_model_option_overrides(
+        selected_model,
+        model_option_overrides,
+    )?);
+    let mut options_to_validate = config::ModelOptionsConfig::new();
+    options_to_validate.insert(full_model_id, model_options.clone());
+    config::file::validate_model_options(&options_to_validate)?;
+
     super::config_for_selected_model(
         selected_model,
         api_key,
         keywords,
         ostt_config.providers.clone(),
+        model_options,
     )
+}
+
+fn parse_model_option_overrides(
+    selected_model: &SelectedModel,
+    overrides: &[String],
+) -> anyhow::Result<IndexMap<String, config::ModelOptionValue>> {
+    let schema = super::api::option_schema(&selected_model.provider_id, &selected_model.model_id)
+        .ok_or_else(|| anyhow::anyhow!("No model options are supported for this model"))?;
+    let full_model_id = format!("{}/{}", selected_model.provider_id, selected_model.model_id);
+    let mut parsed = IndexMap::new();
+
+    for override_value in overrides {
+        let (name, raw_value) = override_value
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("Invalid --mo '{}'. Use key=value.", override_value))?;
+        if parsed.contains_key(name) {
+            anyhow::bail!("Duplicate --mo option '{}'.", name);
+        }
+        let Some(spec) = schema.option(name) else {
+            anyhow::bail!(
+                "Invalid option '{}' for '{}'. Supported options: {}.",
+                name,
+                full_model_id,
+                schema.option_names().join(", ")
+            );
+        };
+        parsed.insert(
+            name.to_string(),
+            parse_model_option_value(raw_value, spec.kind)?,
+        );
+    }
+
+    Ok(parsed)
+}
+
+fn parse_model_option_value(
+    raw_value: &str,
+    kind: super::model::ModelOptionKind,
+) -> anyhow::Result<config::ModelOptionValue> {
+    Ok(match kind {
+        super::model::ModelOptionKind::Bool => {
+            config::ModelOptionValue::Bool(raw_value.parse::<bool>()?)
+        }
+        super::model::ModelOptionKind::BoolOrString => match raw_value.parse::<bool>() {
+            Ok(value) => config::ModelOptionValue::Bool(value),
+            Err(_) => config::ModelOptionValue::String(raw_value.to_string()),
+        },
+        super::model::ModelOptionKind::BoolOrStringList => match raw_value.parse::<bool>() {
+            Ok(value) => config::ModelOptionValue::Bool(value),
+            Err(_) => config::ModelOptionValue::StringList(
+                raw_value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToString::to_string)
+                    .collect(),
+            ),
+        },
+        super::model::ModelOptionKind::Integer => {
+            config::ModelOptionValue::Integer(raw_value.parse::<i64>()?)
+        }
+        super::model::ModelOptionKind::Number => {
+            config::ModelOptionValue::Number(raw_value.parse::<f64>()?)
+        }
+        super::model::ModelOptionKind::String => {
+            config::ModelOptionValue::String(raw_value.to_string())
+        }
+        super::model::ModelOptionKind::StringOrStringList => {
+            if raw_value.contains(',') {
+                config::ModelOptionValue::StringList(parse_comma_separated_strings(raw_value))
+            } else {
+                config::ModelOptionValue::String(raw_value.to_string())
+            }
+        }
+        super::model::ModelOptionKind::StringList => {
+            config::ModelOptionValue::StringList(parse_comma_separated_strings(raw_value))
+        }
+    })
+}
+
+fn parse_comma_separated_strings(raw_value: &str) -> Vec<String> {
+    raw_value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selected_model(provider_id: &str, model_id: &str) -> SelectedModel {
+        SelectedModel {
+            provider_id: provider_id.to_string(),
+            model_id: model_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn model_option_overrides_reject_duplicate_keys() {
+        let model = selected_model("deepgram", "nova-3");
+        let err = parse_model_option_overrides(
+            &model,
+            &["language=sv".to_string(), "language=en".to_string()],
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("Duplicate --mo option 'language'"));
+    }
+
+    #[test]
+    fn model_option_overrides_reject_missing_equals() {
+        let model = selected_model("deepgram", "nova-3");
+        let err = parse_model_option_overrides(&model, &["diarize".to_string()])
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("Invalid --mo 'diarize'"));
+        assert!(err.contains("key=value"));
+    }
+
+    #[test]
+    fn model_option_overrides_reject_unknown_option() {
+        let model = selected_model("openai", "gpt-4o-transcribe");
+        let err = parse_model_option_overrides(&model, &["smart_format=true".to_string()])
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("Invalid option 'smart_format'"));
+        assert!(err.contains("Supported options"));
+    }
+
+    #[test]
+    fn model_option_overrides_reject_invalid_bool_and_number_values() {
+        let bool_model = selected_model("deepgram", "nova-3");
+        let err = parse_model_option_overrides(&bool_model, &["diarize=yes".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("provided string was not `true` or `false`"));
+
+        let number_model = selected_model("openai", "gpt-4o-transcribe");
+        let err = parse_model_option_overrides(&number_model, &["temperature=hot".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid float literal"));
+    }
+
+    #[test]
+    fn model_option_overrides_parse_bool_or_string_list_bool() {
+        let model = selected_model("deepgram", "nova-3");
+        let options =
+            parse_model_option_overrides(&model, &["detect_language=false".to_string()]).unwrap();
+
+        assert_eq!(
+            options.get("detect_language"),
+            Some(&config::ModelOptionValue::Bool(false))
+        );
+    }
+
+    #[test]
+    fn model_option_overrides_parse_string_lists() {
+        let model = selected_model("deepgram", "nova-3");
+        let options =
+            parse_model_option_overrides(&model, &["keyterm=OSTT,whisper".to_string()]).unwrap();
+
+        assert_eq!(
+            options.get("keyterm"),
+            Some(&config::ModelOptionValue::StringList(vec![
+                "OSTT".to_string(),
+                "whisper".to_string()
+            ]))
+        );
+    }
+
+    #[test]
+    fn model_option_overrides_parse_bool_or_string_lists() {
+        let model = selected_model("deepgram", "nova-3");
+        let options =
+            parse_model_option_overrides(&model, &["detect_language=sv,en".to_string()]).unwrap();
+
+        assert_eq!(
+            options.get("detect_language"),
+            Some(&config::ModelOptionValue::StringList(vec![
+                "sv".to_string(),
+                "en".to_string()
+            ]))
+        );
+    }
 }

--- a/src/transcription/context.rs
+++ b/src/transcription/context.rs
@@ -145,9 +145,15 @@ fn parse_model_option_value(
             config::ModelOptionValue::Number(raw_value.parse::<f64>()?)
         }
         super::model::ModelOptionKind::String => {
+            if raw_value.is_empty() {
+                anyhow::bail!("Value must not be empty for string option");
+            }
             config::ModelOptionValue::String(raw_value.to_string())
         }
         super::model::ModelOptionKind::StringOrStringList => {
+            if raw_value.is_empty() {
+                anyhow::bail!("Value must not be empty for string option");
+            }
             if raw_value.contains(',') {
                 config::ModelOptionValue::StringList(parse_comma_separated_strings(raw_value))
             } else {
@@ -228,6 +234,15 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("invalid float literal"));
+    }
+
+    #[test]
+    fn model_option_overrides_reject_empty_string_for_string_typed_option() {
+        let model = selected_model("openai", "gpt-4o-transcribe");
+        let err = parse_model_option_overrides(&model, &["prompt=".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must not be empty"));
     }
 
     #[test]

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -22,7 +22,7 @@ pub mod provider;
 pub use animation::TranscriptionAnimation;
 pub use api::{transcribe, TranscriptionConfig, TranscriptionResponse};
 pub(crate) use context::build_context;
-pub use model::{all_models, find_model, models_for_provider, ModelSpec};
+pub use model::{all_models, find_model, models_for_provider, ModelOptionKind, ModelSpec};
 pub use provider::TranscriptionProvider;
 
 pub fn config_for_selected_model(
@@ -30,6 +30,7 @@ pub fn config_for_selected_model(
     api_key: Option<String>,
     keywords: Vec<String>,
     providers: crate::config::file::ProvidersConfig,
+    model_options: indexmap::IndexMap<String, crate::config::ModelOptionValue>,
 ) -> anyhow::Result<TranscriptionConfig> {
     let provider =
         TranscriptionProvider::from_id(&selected_model.provider_id).ok_or_else(|| {
@@ -45,10 +46,11 @@ pub fn config_for_selected_model(
             selected_model.model_id.clone(),
             keywords,
             providers,
+            model_options,
         ));
     }
 
-    find_model(&selected_model.provider_id, &selected_model.model_id).ok_or_else(|| {
+    let model = find_model(&selected_model.provider_id, &selected_model.model_id).ok_or_else(|| {
         anyhow::anyhow!(
             "Unknown model '{}' for provider '{}'. Please run 'ostt model' to select a supported model.",
             selected_model.model_id,
@@ -63,9 +65,11 @@ pub fn config_for_selected_model(
     Ok(TranscriptionConfig::new_cloud(
         provider,
         selected_model.model_id.clone(),
+        model.endpoint,
         api_key,
         keywords,
         providers,
+        model_options,
     ))
 }
 

--- a/src/transcription/model.rs
+++ b/src/transcription/model.rs
@@ -6,9 +6,66 @@ use super::provider::TranscriptionProvider;
 pub struct ModelSpec {
     pub provider_id: &'static str,
     pub model_id: &'static str,
+    pub endpoint: &'static str,
     pub display_name: &'static str,
     pub description: &'static str,
     pub languages: &'static [&'static str],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelOptionKind {
+    Bool,
+    BoolOrString,
+    BoolOrStringList,
+    Integer,
+    Number,
+    String,
+    StringOrStringList,
+    StringList,
+}
+
+impl ModelOptionKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Bool => "boolean",
+            Self::BoolOrString => "boolean or string",
+            Self::BoolOrStringList => "boolean or string list",
+            Self::Integer => "integer",
+            Self::Number => "number",
+            Self::String => "string",
+            Self::StringOrStringList => "string or string list",
+            Self::StringList => "string list",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelOptionSpec {
+    pub name: &'static str,
+    pub kind: ModelOptionKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelOptionSchema {
+    options: &'static [ModelOptionSpec],
+}
+
+impl ModelOptionSchema {
+    pub(crate) const fn new(options: &'static [ModelOptionSpec]) -> Self {
+        Self { options }
+    }
+
+    pub fn option(&self, name: &str) -> Option<&'static ModelOptionSpec> {
+        self.options.iter().find(|option| option.name == name)
+    }
+
+    pub fn option_names(&self) -> Vec<&'static str> {
+        self.options.iter().map(|option| option.name).collect()
+    }
+
+    pub fn options(&self) -> &'static [ModelOptionSpec] {
+        self.options
+    }
 }
 
 impl ModelSpec {
@@ -17,141 +74,19 @@ impl ModelSpec {
     }
 }
 
-const MODELS: &[ModelSpec] = &[
-    ModelSpec {
-        provider_id: "openai",
-        model_id: "gpt-4o-transcribe",
-        display_name: "GPT-4o Transcribe (latest, best accuracy)",
-        description: "OpenAI's higher-quality speech-to-text model for transcribing audio in the source language. Supports prompting for domain terms, names, and preferred writing style.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "openai",
-        model_id: "gpt-4o-mini-transcribe",
-        display_name: "GPT-4o Mini Transcribe (faster, lighter)",
-        description: "OpenAI's smaller GPT-4o transcription model, intended for faster and lower-cost speech-to-text while retaining support for prompts and plain text or JSON output.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "openai",
-        model_id: "whisper-1",
-        display_name: "Whisper (legacy)",
-        description: "OpenAI's hosted Whisper model. Supports transcription in the source language, translation to English, verbose JSON, SRT/VTT output, and segment or word timestamps.",
-        languages: &["Multilingual", "translation to English"],
-    },
-    ModelSpec {
-        provider_id: "deepgram",
-        model_id: "nova-3",
-        display_name: "Nova 3 (latest, fastest)",
-        description: "Deepgram's highest-performing general-purpose ASR model for batch or streaming use cases including meetings, event captioning, multi-speaker audio, noisy audio, far-field audio, and multilingual transcription.",
-        languages: &["Multilingual", "Swedish", "Norwegian", "English"],
-    },
-    ModelSpec {
-        provider_id: "deepgram",
-        model_id: "nova-2",
-        display_name: "Nova 2 (previous generation)",
-        description: "Deepgram's previous-generation Nova model. Useful when a language or feature is better covered by Nova 2, including filler word identification and broad multilingual speech recognition.",
-        languages: &["Multilingual", "Swedish", "Norwegian", "English"],
-    },
-    ModelSpec {
-        provider_id: "groq",
-        model_id: "whisper-large-v3",
-        display_name: "Whisper Large V3 (high accuracy)",
-        description: "Groq-hosted Whisper Large V3 for error-sensitive multilingual transcription and translation. Groq documents this option as the higher-accuracy choice among its Whisper models.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "groq",
-        model_id: "whisper-large-v3-turbo",
-        display_name: "Whisper Large V3 Turbo (fastest)",
-        description: "Groq-hosted Whisper Large V3 Turbo, a fine-tuned and pruned Large V3 variant designed for fast multilingual transcription with strong price/performance tradeoffs.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "deepinfra",
-        model_id: "openai/whisper-large-v3",
-        display_name: "OpenAI Whisper Large V3 (best accuracy)",
-        description: "OpenAI Whisper Large V3 hosted through DeepInfra. A general-purpose multilingual Whisper model suited for high-accuracy transcription and translation workloads.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "deepinfra",
-        model_id: "openai/whisper-base",
-        display_name: "OpenAI Whisper Base (fast, lightweight)",
-        description: "OpenAI Whisper Base hosted through DeepInfra. A smaller Whisper model option for lighter and faster multilingual transcription workloads.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "assemblyai",
-        model_id: "universal-3-pro",
-        display_name: "Universal 3 Pro (best accuracy)",
-        description: "AssemblyAI's Universal-3 Pro speech-to-text model for high-accuracy transcription and audio understanding in cloud workflows.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "berget",
-        model_id: "KBLab/kb-whisper-large",
-        display_name: "KBLab KB Whisper Large (Swedish optimized)",
-        description: "KBLab's Swedish-optimized Whisper Large model from the National Library of Sweden, trained on more than 50,000 hours of Swedish speech. KBLab reports substantially lower Swedish WER than OpenAI Whisper Large V3 across FLEURS, CommonVoice, and NST evaluations.",
-        languages: &["Swedish"],
-    },
-    ModelSpec {
-        provider_id: "berget",
-        model_id: "NbAiLab/nb-whisper-large",
-        display_name: "NbAiLab NB Whisper Large (Norwegian optimized)",
-        description: "NbAiLab's Norwegian NB-Whisper Large model from the National Library of Norway. It is trained on about 66,000 hours of speech and targets Norwegian ASR, including Bokmal, Nynorsk, English, and varied regional Norwegian speech.",
-        languages: &["Norwegian", "Bokmal", "Nynorsk", "English"],
-    },
-    ModelSpec {
-        provider_id: "berget",
-        model_id: "openai/whisper-large-v3",
-        display_name: "OpenAI Whisper Large V3 (general-purpose)",
-        description: "General-purpose OpenAI Whisper Large V3 hosted through Berget for multilingual transcription and translation when no Swedish- or Norwegian-specialized model is preferred.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "elevenlabs",
-        model_id: "scribe_v2",
-        display_name: "Scribe v2 (highest accuracy, 99 languages)",
-        description: "ElevenLabs' latest Scribe speech-to-text model for high-accuracy transcription with broad multilingual support, including support for many languages beyond English.",
-        languages: &["Multilingual", "99 languages"],
-    },
-    ModelSpec {
-        provider_id: "elevenlabs",
-        model_id: "scribe_v1",
-        display_name: "Scribe v1 (previous generation)",
-        description: "ElevenLabs' previous-generation Scribe speech-to-text model for multilingual transcription workloads.",
-        languages: &["Multilingual", "99 languages"],
-    },
-    ModelSpec {
-        provider_id: "mistral",
-        model_id: "voxtral-mini-latest",
-        display_name: "Voxtral Mini Transcribe (fast, efficient, 13 languages)",
-        description: "Mistral's Voxtral Mini transcription model for fast, efficient multilingual speech-to-text via the Mistral API.",
-        languages: &["Multilingual"],
-    },
-    ModelSpec {
-        provider_id: "mistral",
-        model_id: "voxtral-mini-2602",
-        display_name: "Voxtral Mini 2602 (newer version, improved accuracy)",
-        description: "Pinned Voxtral Mini 2602 transcription model for stable Mistral speech-to-text behavior.",
-        languages: &["Multilingual"],
-    },
-];
-
-pub fn all_models() -> &'static [ModelSpec] {
-    MODELS
+pub fn all_models() -> Vec<&'static ModelSpec> {
+    super::api::all_models()
 }
 
 pub fn find_model(provider_id: &str, model_id: &str) -> Option<&'static ModelSpec> {
-    MODELS
-        .iter()
+    all_models()
+        .into_iter()
         .find(|model| model.provider_id == provider_id && model.model_id == model_id)
 }
 
 pub fn models_for_provider(provider: &TranscriptionProvider) -> Vec<&'static ModelSpec> {
-    MODELS
-        .iter()
+    all_models()
+        .into_iter()
         .filter(|model| model.provider_id == provider.id())
         .collect()
 }


### PR DESCRIPTION
## Summary
- Add model-scoped transcription request options under `[model_options."provider/model"]` and repeatable per-run `--mo key=value` overrides.
- Add `ostt model options [PROVIDER/MODEL] --format table|json` for listing supported option keys.
- Move cloud model specs, endpoint metadata, option schemas, request wiring, and provider-specific validation into provider modules.
- Validate documented JSON-safe options for OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, ElevenLabs, Mistral, and local transcription.
- Keep saved `ostt keyword` terms as fallback-only hints so explicit model options are never appended or overwritten.

## Notable Behavior
- Cloud model IDs use `provider/model` identity and stale OSTT-invented IDs are rejected.
- `-m, --model <PROVIDER/MODEL>` is per-run only and does not persist config.
- `--mo` duplicate keys, unsupported keys, invalid types, invalid ranges, and provider-specific invalid combinations fail before requests are sent.
- Provider-level request option config is intentionally not migrated; stale `[providers.*]` request options fail loudly.

## Verification
- `cargo fmt --check`
- `cargo test --lib model_options -- --nocapture`
- `cargo test --lib elevenlabs -- --nocapture`
- `cargo test --lib mistral -- --nocapture`
- `cargo test --lib assemblyai -- --nocapture`
- `cargo clippy --lib -- -D warnings`
- `cargo test --lib` (177 passed)