### PR TITLE
Clean up transcription params config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced public transcription model option terminology with params: use repeatable `--param key=value` and `ostt model params [PROVIDER/MODEL] --format table|json`.
+- Moved persistent transcription params to top-level provider tables: `[provider.params]` for provider defaults and `[provider."model".params]` for model overrides.
+- Renamed the built-in local Whisper provider ID from `local` to `whisper`, so local model IDs use `whisper/<model>`.
+- Local Whisper audio format is now resolved from `[whisper].output_format`, `[whisper."model"].output_format`, or the built-in Whisper default instead of mutating global `[audio].output_format`.
+
+### Removed
+
+- Removed support for deprecated `[providers]`, `[model_options]`, `[audio].sample_rate`, `[[process.actions]]`, and `provider = "local"` config shapes. OSTT now fails loudly with targeted configuration errors for these old formats.
+
 ## 0.0.17 - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OSTT is built for people who treat the terminal as a normal place for voice inpu
 
 - **Linux-first voice input** - Global hotkey setup for Omarchy/Hyprland, GNOME, KDE, and other Linux desktops, with macOS support too.
 - **Provider choice** - Bring your own API key and switch between OpenAI, Deepgram, Groq, DeepInfra, AssemblyAI, Berget, ElevenLabs, Mistral, and local Whisper-compatible models.
-- **Model-scoped options** - Tune supported provider/model request options persistently or per run with `--mo key=value`.
+- **Model-scoped params** - Tune supported provider/model request params persistently or per run with `--param key=value`.
 - **Local transcription models** - Download curated local models or add custom Hugging Face/direct model files for offline transcription.
 - **Terminal-native workflow** - Use stdout, clipboard, files, aliases, shell completions, logs, and pipes.
 - **Scriptable post-processing** - Transform transcripts with AI prompts or bash commands using `ostt -p` and `ostt process`.
@@ -79,7 +79,7 @@ ostt model          # Choose cloud or local transcription model
 ostt                # Record, transcribe, print to stdout
 ostt -c             # Record, transcribe, copy to clipboard
 ostt -m deepgram/nova-3 -c
-ostt -m local/turbo --mo language=sv -c
+ostt -m whisper/turbo --param language=sv -c
 ostt launch -c      # Popup workflow for global hotkeys
 ```
 
@@ -107,13 +107,13 @@ ostt                         # Record audio, print transcription
 ostt -c                      # Record audio, copy transcription
 ostt -o notes.txt            # Record audio, write transcription to file
 ostt -m openai/whisper-1     # Override model for this run
-ostt --mo language=sv -c     # Override a model option for this run
+ostt --param language=sv -c  # Override a transcription param for this run
 ostt launch -c               # Open popup recorder
 ostt transcribe file.mp3 -m deepinfra/openai/whisper-large-v3
 ostt retry 2 -m groq/whisper-large-v3 -c
 ostt replay                  # Play most recent recording
 ostt model                   # Choose cloud or local transcription model
-ostt model options local/turbo   # List supported options for a model
+ostt model params whisper/turbo  # List supported params for a model
 ostt history                 # Browse transcription history
 ostt keyword                 # Manage transcription keywords
 ostt config                  # Open config file
@@ -135,7 +135,9 @@ Run `ostt auth` to select your provider/model and save credentials securely.
 
 Run `ostt model` to switch between authenticated cloud models and local models. The local model screen can download curated models, activate downloaded models, delete local model files, and add custom models from Hugging Face model pages or direct `.gguf` / `ggml-*.bin` URLs.
 
-Per-model options are configured under `[model_options."provider/model"]` or passed per run with `--mo key=value`. See [Providers and Models](https://ostt.ai/reference/providers) and [Configuration](https://ostt.ai/guide/configuration) for supported options.
+Per-provider and per-model params are configured under `[provider.params]` and `[provider."model".params]`, or passed per run with `--param key=value`. See [Providers and Models](https://ostt.ai/reference/providers) and [Configuration](https://ostt.ai/guide/configuration) for supported params.
+
+Deprecated config shapes such as `[providers]`, `[model_options]`, `[audio].sample_rate`, `[[process.actions]]`, and `provider = "local"` fail loudly. Update local model IDs from `local/<model>` to `whisper/<model>`.
 
 ## Platform Setup
 

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -40,23 +40,33 @@ reference_level_db = -20
 # Add more formats as needed - ffmpeg handles the rest!
 output_format = "mp3 -ab 16k -ar 12000"
 
-# Per-model transcription request options.
-# Keys must use the full provider/model id and options are validated against that model.
+# Provider and per-model transcription params.
+# Provider params apply to all models for that provider. Model params override provider params.
 #
 # Examples:
-# [model_options."deepgram/nova-3"]
+# [deepgram.params]
+# detect_language = true
+# smart_format = true
+#
+# [deepgram.nova-3.params]
 # detect_language = true
 # smart_format = true
 # keyterm = ["OSTT"]
 #
-# [model_options."berget/openai/whisper-large-v3"]
+# [berget."openai/whisper-large-v3".params]
 # language = "sv"
 #
-# Local Whisper-compatible models support the same option keys per model.
-# [model_options."local/turbo"]
+# Built-in local Whisper models use the whisper provider.
+# [whisper]
+# output_format = "pcm_s16le -ar 16000"
+#
+# [whisper.params]
 # language = "auto"
 # no_timestamps = true
 # no_context = true
 # temperature = 0.0
 # entropy_thold = 2.4
 # no_speech_thold = 0.6
+#
+# [whisper.turbo.params]
+# language = "sv"

--- a/src/app.rs
+++ b/src/app.rs
@@ -48,11 +48,6 @@ async fn check_and_run_setup() -> Result<(), anyhow::Error> {
                 })?;
             }
 
-            crate::setup::version::run_config_migrations(&config_path).map_err(|e| {
-                tracing::error!("Config migration failed: {e}");
-                anyhow!("Config migration failed: {e}")
-            })?;
-
             crate::setup::version::update_config_version(&config_path).map_err(|e| {
                 tracing::error!("Failed to update config version: {e}");
                 anyhow!("Failed to update config version: {e}")
@@ -64,10 +59,6 @@ async fn check_and_run_setup() -> Result<(), anyhow::Error> {
         }
         None => {
             // Config exists and version matches, no setup needed
-            crate::setup::version::run_config_migrations(&config_path).map_err(|e| {
-                tracing::error!("Config migration failed: {e}");
-                anyhow!("Config migration failed: {e}")
-            })?;
             tracing::debug!("Config version up to date ({})", env!("CARGO_PKG_VERSION"));
         }
     }
@@ -78,7 +69,7 @@ async fn check_and_run_setup() -> Result<(), anyhow::Error> {
 fn load_config() -> anyhow::Result<crate::config::OsttConfig> {
     crate::config::OsttConfig::load().map_err(|err| {
         tracing::error!("Failed to load configuration: {err}");
-        anyhow!("Configuration error: {err}\n\nPlease check your ~/.config/ostt/ostt.toml file and try again.")
+        anyhow!("Configuration error: {err}\nPlease check your ~/.config/ostt/ostt.toml file and try again.")
     })
 }
 
@@ -110,9 +101,9 @@ struct Cli {
     #[arg(short = 'm', long = "model", value_name = "PROVIDER/MODEL")]
     model: Option<String>,
 
-    /// Override a model option for this run, as key=value
-    #[arg(long = "mo", value_name = "KEY=VALUE", global = true)]
-    model_options: Vec<String>,
+    /// Override a transcription param for this run, as key=value
+    #[arg(long = "param", value_name = "KEY=VALUE", global = true)]
+    params: Vec<String>,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -388,8 +379,8 @@ enum ModelCommand {
     },
     /// Show the currently selected transcription model
     Current,
-    /// List supported model options for a transcription model
-    Options {
+    /// List supported transcription params for a transcription model
+    Params {
         /// Model to inspect. Defaults to the currently selected model.
         #[arg(value_name = "PROVIDER/MODEL")]
         model: Option<String>,
@@ -642,6 +633,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
         Some(Commands::Logs {
             command: Some(LogsCommand::Follow),
         }) => return commands::logs::handle_logs_follow(),
+        Some(Commands::Config { command: None }) => {
+            check_and_run_setup().await?;
+            return commands::handle_config();
+        }
+        Some(Commands::Config {
+            command: Some(ConfigCommand::Path),
+        }) => return commands::config::handle_config_path(),
         _ => {}
     }
 
@@ -679,7 +677,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 output,
                 process,
                 model_override,
-                &cli.model_options,
+                &cli.params,
             )
             .await?;
         }
@@ -702,7 +700,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 output,
                 process,
                 model_override,
-                &cli.model_options,
+                &cli.params,
             )
             .await?;
         }
@@ -725,7 +723,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 output,
                 process,
                 model_override,
-                &cli.model_options,
+                &cli.params,
             )
             .await?;
         }
@@ -763,8 +761,8 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 format,
             }) => commands::model::handle_model_list(provider, installed, format.is_json()).await?,
             Some(ModelCommand::Current) => commands::model::handle_model_current()?,
-            Some(ModelCommand::Options { model, format }) => {
-                commands::model::handle_model_options(model, format.is_json())?
+            Some(ModelCommand::Params { model, format }) => {
+                commands::model::handle_model_params(model, format.is_json())?
             }
             Some(ModelCommand::Select { model }) => {
                 commands::model::handle_model_select(model).await?
@@ -843,9 +841,9 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 full_args.insert(0, model.clone());
                 full_args.insert(0, "-m".to_string());
             }
-            for model_option in cli.model_options.iter().rev() {
-                full_args.insert(0, model_option.clone());
-                full_args.insert(0, "--mo".to_string());
+            for param in cli.params.iter().rev() {
+                full_args.insert(0, param.clone());
+                full_args.insert(0, "--param".to_string());
             }
             commands::handle_launch(&config_data, full_args).await?;
         }
@@ -957,11 +955,11 @@ mod tests {
     }
 
     #[test]
-    fn cli_accepts_model_options_listing_format() {
+    fn cli_accepts_model_params_listing_format() {
         let cli = Cli::try_parse_from([
             "ostt",
             "model",
-            "options",
+            "params",
             "openai/gpt-4o-transcribe",
             "--format",
             "json",
@@ -971,7 +969,7 @@ mod tests {
         match cli.command {
             Some(Commands::Model {
                 command:
-                    Some(ModelCommand::Options {
+                    Some(ModelCommand::Params {
                         model: Some(model),
                         format,
                     }),
@@ -979,7 +977,7 @@ mod tests {
                 assert_eq!(model, "openai/gpt-4o-transcribe");
                 assert_eq!(format, ListFormat::Json);
             }
-            _ => panic!("expected model options command"),
+            _ => panic!("expected model params command"),
         }
     }
 
@@ -1041,28 +1039,29 @@ mod tests {
     }
 
     #[test]
-    fn cli_accepts_repeatable_model_options_for_default_record() {
+    fn cli_accepts_repeatable_params_for_default_record() {
         let cli = Cli::try_parse_from([
             "ostt",
-            "--mo",
+            "--param",
             "detect_language=false",
-            "--mo",
+            "--param",
             "smart_format=true",
         ])
         .expect("parse cli");
 
         assert_eq!(
-            cli.model_options,
+            cli.params,
             vec!["detect_language=false", "smart_format=true"]
         );
     }
 
     #[test]
-    fn cli_accepts_model_options_for_transcribe() {
-        let cli = Cli::try_parse_from(["ostt", "transcribe", "audio.ogg", "--mo", "language=sv"])
-            .expect("parse cli");
+    fn cli_accepts_params_for_transcribe() {
+        let cli =
+            Cli::try_parse_from(["ostt", "transcribe", "audio.ogg", "--param", "language=sv"])
+                .expect("parse cli");
 
-        assert_eq!(cli.model_options, vec!["language=sv"]);
+        assert_eq!(cli.params, vec!["language=sv"]);
         match cli.command {
             Some(Commands::Transcribe { .. }) => {}
             _ => panic!("expected transcribe command"),
@@ -1070,34 +1069,35 @@ mod tests {
     }
 
     #[test]
-    fn cli_collects_model_options_once_for_subcommands() {
+    fn cli_collects_params_once_for_subcommands() {
         let cli = Cli::try_parse_from([
             "ostt",
             "transcribe",
             "audio.ogg",
-            "--mo",
+            "--param",
             "diarize=true",
-            "--mo",
+            "--param",
             "language=sv",
         ])
         .expect("parse cli");
 
-        assert_eq!(cli.model_options, vec!["diarize=true", "language=sv"]);
+        assert_eq!(cli.params, vec!["diarize=true", "language=sv"]);
     }
 
     #[test]
-    fn cli_accepts_model_options_for_launch() {
+    fn cli_accepts_params_for_launch() {
         let cli =
-            Cli::try_parse_from(["ostt", "launch", "--mo", "language=sv"]).expect("parse cli");
+            Cli::try_parse_from(["ostt", "launch", "--param", "language=sv"]).expect("parse cli");
 
-        assert_eq!(cli.model_options, vec!["language=sv"]);
+        assert_eq!(cli.params, vec!["language=sv"]);
     }
 
     #[test]
-    fn cli_accepts_global_model_options_before_subcommand() {
-        let cli = Cli::try_parse_from(["ostt", "--mo", "language=sv", "transcribe", "audio.ogg"])
-            .expect("parse cli");
+    fn cli_accepts_global_params_before_subcommand() {
+        let cli =
+            Cli::try_parse_from(["ostt", "--param", "language=sv", "transcribe", "audio.ogg"])
+                .expect("parse cli");
 
-        assert_eq!(cli.model_options, vec!["language=sv"]);
+        assert_eq!(cli.params, vec!["language=sv"]);
     }
 }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -176,7 +176,7 @@ fn provider_by_id(
 fn cloud_providers() -> Vec<transcription::TranscriptionProvider> {
     transcription::TranscriptionProvider::all()
         .iter()
-        .filter(|provider| **provider != transcription::TranscriptionProvider::Local)
+        .filter(|provider| **provider != transcription::TranscriptionProvider::Whisper)
         .cloned()
         .collect()
 }
@@ -273,7 +273,7 @@ mod tests {
     fn login_provider_options_exclude_local() {
         let providers = cloud_providers();
 
-        assert!(!providers.contains(&transcription::TranscriptionProvider::Local));
+        assert!(!providers.contains(&transcription::TranscriptionProvider::Whisper));
         assert!(providers.contains(&transcription::TranscriptionProvider::OpenAI));
     }
 

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -226,7 +226,7 @@ fn active_local_model() -> Option<String> {
     crate::config::get_selected_model_entry()
         .ok()
         .flatten()
-        .filter(|m| m.provider_id == "local")
+        .filter(|m| m.provider_id == "whisper")
         .map(|m| m.model_id)
 }
 

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -45,7 +45,7 @@ pub async fn handle_model_list(
         }
     }
 
-    if provider.as_deref().is_none_or(|id| id == "local") {
+    if provider.as_deref().is_none_or(|id| id == "whisper") {
         let state = local_models::load_state();
         let registry = local_models::fetch_registry().await.unwrap_or_default();
         for entry in registry.iter().chain(state.custom_models.iter()) {
@@ -54,12 +54,12 @@ pub async fn handle_model_list(
                 continue;
             }
             rows.push(ModelListRow {
-                provider: "local".to_string(),
+                provider: "whisper".to_string(),
                 model: entry.id.clone(),
                 name: entry.name.clone(),
                 installed: Some(is_installed),
                 active: selected.as_ref().is_some_and(|selected| {
-                    selected.provider_id == "local" && selected.model_id == entry.id
+                    selected.provider_id == "whisper" && selected.model_id == entry.id
                 }),
             });
         }
@@ -106,7 +106,7 @@ pub fn handle_model_current() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn handle_model_options(model: Option<String>, json: bool) -> anyhow::Result<()> {
+pub fn handle_model_params(model: Option<String>, json: bool) -> anyhow::Result<()> {
     let selected = match model {
         Some(model) => crate::config::parse_provider_model(&model)?,
         None => crate::config::get_selected_model_entry()?.ok_or_else(|| {
@@ -115,7 +115,7 @@ pub fn handle_model_options(model: Option<String>, json: bool) -> anyhow::Result
     };
     let full_model_id = format!("{}/{}", selected.provider_id, selected.model_id);
     let schema = transcription::api::option_schema(&selected.provider_id, &selected.model_id)
-        .ok_or_else(|| anyhow::anyhow!("No model options are supported for {full_model_id}."))?;
+        .ok_or_else(|| anyhow::anyhow!("No params are supported for {full_model_id}."))?;
 
     if json {
         let options: Vec<_> = schema
@@ -133,7 +133,7 @@ pub fn handle_model_options(model: Option<String>, json: bool) -> anyhow::Result
             serde_json::to_string_pretty(&serde_json::json!({
                 "provider": selected.provider_id,
                 "model": selected.model_id,
-                "options": options,
+                    "params": options,
             }))?
         );
         return Ok(());
@@ -148,10 +148,10 @@ pub fn handle_model_options(model: Option<String>, json: bool) -> anyhow::Result
 
 pub async fn handle_model_select(model: String) -> anyhow::Result<()> {
     let selected = crate::config::parse_provider_model(&model)?;
-    if selected.provider_id == "local" {
+    if selected.provider_id == "whisper" {
         local_models::activate_model(&selected.model_id)?;
         reload_daemon_if_running(&selected.model_id).await?;
-        println!("Selected local model: local/{}", selected.model_id);
+        println!("Selected whisper model: whisper/{}", selected.model_id);
         return Ok(());
     }
 
@@ -174,11 +174,11 @@ pub async fn handle_model_local_download(model_id: String) -> anyhow::Result<()>
     let entry = find_local_model_entry(&model_id).await?;
     let destination = local_models::model_destination(&entry);
     if destination.exists() {
-        println!("Local model already downloaded: local/{model_id}");
+        println!("Local model already downloaded: whisper/{model_id}");
         return Ok(());
     }
 
-    eprintln!("Downloading local model: local/{model_id}");
+    eprintln!("Downloading local model: whisper/{model_id}");
     local_models::download_model(
         &entry.url,
         &destination,
@@ -190,7 +190,7 @@ pub async fn handle_model_local_download(model_id: String) -> anyhow::Result<()>
     eprintln!();
     local_models::validate_downloaded_model(&entry)?;
     local_models::mark_downloaded_registry_model(&entry)?;
-    println!("Downloaded local model: local/{model_id}");
+    println!("Downloaded local model: whisper/{model_id}");
     Ok(())
 }
 
@@ -202,7 +202,7 @@ pub async fn handle_model_local_remove(model_id: String) -> anyhow::Result<()> {
     if loaded_model_id.as_deref() == Some(model_id.as_str()) {
         crate::transcription::daemon_client::shutdown_daemon().await?;
     }
-    println!("Removed local model: local/{model_id}");
+    println!("Removed local model: whisper/{model_id}");
     Ok(())
 }
 
@@ -229,7 +229,7 @@ async fn find_local_model_entry(model_id: &str) -> anyhow::Result<local_models::
     registry
         .into_iter()
         .find(|entry| entry.id == model_id)
-        .ok_or_else(|| anyhow::anyhow!("Unknown local model: local/{model_id}"))
+        .ok_or_else(|| anyhow::anyhow!("Unknown local model: whisper/{model_id}"))
 }
 
 async fn reload_daemon_if_running(model_id: &str) -> anyhow::Result<()> {

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -30,7 +30,7 @@ pub async fn handle_record(
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<SelectedModel>,
-    model_option_overrides: &[String],
+    param_overrides: &[String],
 ) -> anyhow::Result<()> {
     tracing::info!("=== ostt Audio Recorder Started ===");
     tracing::info!(
@@ -66,7 +66,8 @@ pub async fn handle_record(
     // Once recording has stopped, external triggers should no longer target this process.
     drop(active_recording_guard);
 
-    let Some(filepath) = storage::save_recording(&mut audio_recorder, &config.audio.output_format)
+    let output_format = resolve_recording_output_format(config, model_override.as_ref());
+    let Some(filepath) = storage::save_recording(&mut audio_recorder, &output_format)
         .context("failed to save recording")?
     else {
         return finish_recording_without_output(&mut tui);
@@ -76,7 +77,7 @@ pub async fn handle_record(
     recording_history::prune_old_recordings();
 
     let transcription_context =
-        crate::transcription::build_context(config, model_override, model_option_overrides)
+        crate::transcription::build_context(config, model_override, param_overrides)
             .context("failed to build transcription context")?;
     let model_id = transcription_context.selected_model.model_id.clone();
     let filepath_str = filepath.to_string_lossy().to_string();
@@ -137,6 +138,29 @@ pub async fn handle_record(
             Ok(())
         }
     }
+}
+
+fn resolve_recording_output_format(
+    config: &OsttConfig,
+    model_override: Option<&SelectedModel>,
+) -> String {
+    let selected_model = model_override.cloned().or_else(|| {
+        match (
+            config.transcription.provider.as_ref(),
+            config.transcription.model.as_ref(),
+        ) {
+            (Some(provider_id), Some(model_id)) => Some(SelectedModel {
+                provider_id: provider_id.clone(),
+                model_id: model_id.clone(),
+            }),
+            _ => None,
+        }
+    });
+
+    selected_model
+        .as_ref()
+        .map(|selected_model| crate::config::resolve_output_format(config, selected_model))
+        .unwrap_or_else(|| config.audio.output_format.clone())
 }
 
 fn finish_recording_without_output(tui: &mut RecordingTui) -> anyhow::Result<()> {

--- a/src/commands/retry.rs
+++ b/src/commands/retry.rs
@@ -22,7 +22,7 @@ pub async fn handle_retry(
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<config::SelectedModel>,
-    model_option_overrides: &[String],
+    param_overrides: &[String],
 ) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Retry Command ===");
 
@@ -52,8 +52,7 @@ pub async fn handle_retry(
 
     tracing::info!("Retrying transcription for recording #{}", index);
 
-    let context =
-        transcription::build_context(config_data, model_override, model_option_overrides)?;
+    let context = transcription::build_context(config_data, model_override, param_overrides)?;
 
     // Transcribe
     tracing::debug!("Starting transcription for retry...");

--- a/src/commands/transcribe.rs
+++ b/src/commands/transcribe.rs
@@ -25,7 +25,7 @@ pub async fn handle_transcribe(
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<config::SelectedModel>,
-    model_option_overrides: &[String],
+    param_overrides: &[String],
 ) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Transcribe Command ===");
 
@@ -36,8 +36,7 @@ pub async fn handle_transcribe(
 
     tracing::info!("Transcribing file: {}", file.display());
 
-    let context =
-        transcription::build_context(config_data, model_override, model_option_overrides)?;
+    let context = transcription::build_context(config_data, model_override, param_overrides)?;
 
     // Transcribe
     tracing::debug!("Starting transcription...");

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -78,7 +78,7 @@ fn default_true() -> bool {
     true
 }
 
-/// Local transcription provider configuration.
+/// Built-in whisper.cpp transcription defaults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LocalTranscriptionConfig {
@@ -134,14 +134,6 @@ fn validate_local_values(
     Ok(())
 }
 
-/// All provider configurations
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct ProvidersConfig {
-    #[serde(default)]
-    pub local: LocalTranscriptionConfig,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ModelOptionValue {
@@ -152,7 +144,45 @@ pub enum ModelOptionValue {
     StringList(Vec<String>),
 }
 
-pub type ModelOptionsConfig = IndexMap<String, IndexMap<String, ModelOptionValue>>;
+pub type ParamsConfig = IndexMap<String, ModelOptionValue>;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ProviderSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ProviderModelConfig {
+    #[serde(flatten)]
+    pub settings: ProviderSettings,
+    #[serde(default)]
+    pub params: ParamsConfig,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ProviderConfig {
+    #[serde(flatten)]
+    pub settings: ProviderSettings,
+    #[serde(default)]
+    pub params: ParamsConfig,
+    #[serde(default)]
+    pub models: IndexMap<String, ProviderModelConfig>,
+}
+
+pub type ProviderConfigs = IndexMap<String, ProviderConfig>;
 
 /// Popup window configuration for the `launch` subcommand.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -531,22 +561,28 @@ pub struct TranscriptionSelectionConfig {
     pub model: Option<String>,
 }
 
+const FIXED_TOP_LEVEL_SECTIONS: &[&str] = &["audio", "transcription", "process", "popup"];
+const DEPRECATED_TOP_LEVEL_SECTIONS: &[&str] = &["providers", "model_options"];
+
 /// Complete application configuration.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct OsttConfig {
-    #[serde(default = "current_config_version")]
     pub config_version: String,
     pub audio: AudioConfig,
-    #[serde(default)]
     pub transcription: TranscriptionSelectionConfig,
-    #[serde(default)]
-    pub providers: ProvidersConfig,
-    #[serde(default)]
-    pub model_options: ModelOptionsConfig,
-    #[serde(default)]
+    pub provider_configs: ProviderConfigs,
     pub process: ProcessConfig,
-    #[serde(default)]
     pub popup: PopupConfig,
+}
+
+impl<'de> Deserialize<'de> for OsttConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut table = toml::Table::deserialize(deserializer)?;
+        parse_config_table(&mut table).map_err(serde::de::Error::custom)
+    }
 }
 
 impl OsttConfig {
@@ -560,8 +596,7 @@ impl OsttConfig {
         let config_path = get_config_path()?;
         let config_content = fs::read_to_string(&config_path)?;
         let config: OsttConfig = toml::from_str(&config_content)?;
-        config.providers.local.validate()?;
-        validate_model_options(&config.model_options)?;
+        validate_config(&config)?;
         for action in &config.process.actions {
             action.validate()?;
         }
@@ -575,7 +610,7 @@ impl OsttConfig {
     /// - If the file cannot be written
     pub fn save(&self) -> anyhow::Result<()> {
         let config_path = get_config_path()?;
-        let config_content = toml::to_string_pretty(self)?;
+        let config_content = toml::to_string_pretty(&config_to_table(self)?)?;
         fs::write(&config_path, config_content)?;
         tracing::info!("Configuration saved");
         Ok(())
@@ -594,12 +629,353 @@ impl OsttConfig {
                 visualization: VisualizationType::default(),
             },
             transcription: TranscriptionSelectionConfig::default(),
-            providers: ProvidersConfig::default(),
-            model_options: ModelOptionsConfig::default(),
+            provider_configs: ProviderConfigs::default(),
             process: ProcessConfig::default(),
             popup: PopupConfig::default(),
         }
     }
+}
+
+fn parse_config_table(table: &mut toml::Table) -> anyhow::Result<OsttConfig> {
+    reject_deprecated_top_level_sections(table)?;
+    reject_deprecated_section_keys(table)?;
+
+    let config_version = match table.remove("config_version") {
+        Some(value) => value.try_into()?,
+        None => current_config_version(),
+    };
+    let audio = take_required_section::<AudioConfig>(table, "audio")?;
+    let transcription =
+        take_optional_section::<TranscriptionSelectionConfig>(table, "transcription")?;
+    let process = take_optional_section::<ProcessConfig>(table, "process")?;
+    let popup = take_optional_section::<PopupConfig>(table, "popup")?;
+
+    let mut provider_configs = ProviderConfigs::new();
+    let provider_tables = std::mem::take(table);
+    for (provider_id, value) in provider_tables {
+        if FIXED_TOP_LEVEL_SECTIONS.contains(&provider_id.as_str()) {
+            anyhow::bail!("duplicate top-level section '{provider_id}'");
+        }
+        if crate::transcription::TranscriptionProvider::from_id(&provider_id).is_none() {
+            anyhow::bail!(
+                "Unknown top-level config section '{}'. Expected one of: audio, transcription, process, popup, {}.",
+                provider_id,
+                crate::transcription::TranscriptionProvider::supported_ids().join(", ")
+            );
+        }
+        let toml::Value::Table(provider_table) = value else {
+            anyhow::bail!("Provider config '{provider_id}' must be a table");
+        };
+        provider_configs.insert(
+            provider_id.clone(),
+            parse_provider_config(&provider_id, provider_table)?,
+        );
+    }
+
+    let config = OsttConfig {
+        config_version,
+        audio,
+        transcription,
+        provider_configs,
+        process,
+        popup,
+    };
+    validate_config(&config)?;
+    Ok(config)
+}
+
+fn reject_deprecated_top_level_sections(table: &toml::Table) -> anyhow::Result<()> {
+    for section in DEPRECATED_TOP_LEVEL_SECTIONS {
+        if table.contains_key(*section) {
+            anyhow::bail!(
+                "Deprecated config section '[{}]' is no longer supported. Use top-level provider sections with '.params', for example '[whisper.params]' or '[openai.gpt-4o-transcribe.params]'.",
+                section
+            );
+        }
+    }
+    Ok(())
+}
+
+fn reject_deprecated_section_keys(table: &toml::Table) -> anyhow::Result<()> {
+    if table
+        .get("audio")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|audio| audio.contains_key("sample_rate"))
+    {
+        anyhow::bail!(
+            "Deprecated config key '[audio].sample_rate' is no longer supported. Use '[audio].output_format' instead, for example output_format = \"mp3 -ab 16k -ar 12000\"."
+        );
+    }
+
+    if table
+        .get("process")
+        .and_then(toml::Value::as_table)
+        .and_then(|process| process.get("actions"))
+        .is_some_and(toml::Value::is_array)
+    {
+        anyhow::bail!(
+            "Deprecated config table '[[process.actions]]' is no longer supported. Use named action tables instead, for example '[process.actions.clean]'."
+        );
+    }
+
+    Ok(())
+}
+
+fn take_required_section<T>(table: &mut toml::Table, name: &str) -> anyhow::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let Some(value) = table.remove(name) else {
+        anyhow::bail!("Missing required config section '[{name}]'");
+    };
+    Ok(value.try_into()?)
+}
+
+fn take_optional_section<T>(table: &mut toml::Table, name: &str) -> anyhow::Result<T>
+where
+    T: serde::de::DeserializeOwned + Default,
+{
+    match table.remove(name) {
+        Some(value) => Ok(value.try_into()?),
+        None => Ok(T::default()),
+    }
+}
+
+fn parse_provider_config(provider_id: &str, table: toml::Table) -> anyhow::Result<ProviderConfig> {
+    let mut config = ProviderConfig::default();
+
+    for (key, value) in table {
+        if key == "params" {
+            config.params = parse_params_table(provider_id, None, value)?;
+            continue;
+        }
+
+        if is_provider_setting_key(&key) {
+            set_provider_setting(&mut config.settings, &key, value)?;
+            continue;
+        }
+
+        let toml::Value::Table(model_table) = value else {
+            anyhow::bail!(
+                "Unknown setting '{}' in provider config '[{}]'",
+                key,
+                provider_id
+            );
+        };
+        config.models.insert(
+            key.clone(),
+            parse_provider_model_config(provider_id, &key, model_table)?,
+        );
+    }
+
+    Ok(config)
+}
+
+fn parse_provider_model_config(
+    provider_id: &str,
+    model_id: &str,
+    table: toml::Table,
+) -> anyhow::Result<ProviderModelConfig> {
+    let mut config = ProviderModelConfig::default();
+
+    for (key, value) in table {
+        if key == "params" {
+            config.params = parse_params_table(provider_id, Some(model_id), value)?;
+            continue;
+        }
+
+        if is_provider_setting_key(&key) {
+            set_provider_setting(&mut config.settings, &key, value)?;
+            continue;
+        }
+
+        anyhow::bail!(
+            "Unknown setting '{}' in provider model config '[{}.{}]'",
+            key,
+            provider_id,
+            model_id
+        );
+    }
+
+    Ok(config)
+}
+
+fn parse_params_table(
+    provider_id: &str,
+    model_id: Option<&str>,
+    value: toml::Value,
+) -> anyhow::Result<ParamsConfig> {
+    let toml::Value::Table(table) = value else {
+        anyhow::bail!("Params for provider '{}' must be a table", provider_id);
+    };
+    let params: ParamsConfig = toml::Value::Table(table).try_into()?;
+    if let Some(model_id) = model_id {
+        validate_params_for_model(provider_id, model_id, &params)?;
+    }
+    Ok(params)
+}
+
+fn is_provider_setting_key(key: &str) -> bool {
+    matches!(
+        key,
+        "output_format"
+            | "timeout_secs"
+            | "command"
+            | "endpoint"
+            | "model"
+            | "api_key_env"
+            | "display_name"
+    )
+}
+
+fn set_provider_setting(
+    settings: &mut ProviderSettings,
+    key: &str,
+    value: toml::Value,
+) -> anyhow::Result<()> {
+    match key {
+        "output_format" => settings.output_format = Some(value.try_into()?),
+        "timeout_secs" => settings.timeout_secs = Some(value.try_into()?),
+        "command" => settings.command = Some(value.try_into()?),
+        "endpoint" => settings.endpoint = Some(value.try_into()?),
+        "model" => settings.model = Some(value.try_into()?),
+        "api_key_env" => settings.api_key_env = Some(value.try_into()?),
+        "display_name" => settings.display_name = Some(value.try_into()?),
+        _ => unreachable!("unknown provider setting was pre-filtered"),
+    }
+    Ok(())
+}
+
+fn config_to_table(config: &OsttConfig) -> anyhow::Result<toml::Table> {
+    let mut table = toml::Table::new();
+    table.insert(
+        "config_version".to_string(),
+        toml::Value::String(config.config_version.clone()),
+    );
+    table.insert("audio".to_string(), toml::Value::try_from(&config.audio)?);
+    if config.transcription.provider.is_some() || config.transcription.model.is_some() {
+        table.insert(
+            "transcription".to_string(),
+            toml::Value::try_from(&config.transcription)?,
+        );
+    }
+    for (provider_id, provider_config) in &config.provider_configs {
+        table.insert(
+            provider_id.clone(),
+            provider_config_to_value(provider_config)?,
+        );
+    }
+    if !config.process.actions.is_empty() {
+        table.insert(
+            "process".to_string(),
+            toml::Value::try_from(&config.process)?,
+        );
+    }
+    table.insert("popup".to_string(), toml::Value::try_from(&config.popup)?);
+    Ok(table)
+}
+
+fn provider_config_to_value(config: &ProviderConfig) -> anyhow::Result<toml::Value> {
+    let mut table = provider_settings_to_table(&config.settings)?;
+    if !config.params.is_empty() {
+        table.insert("params".to_string(), toml::Value::try_from(&config.params)?);
+    }
+    for (model_id, model_config) in &config.models {
+        table.insert(
+            model_id.clone(),
+            provider_model_config_to_value(model_config)?,
+        );
+    }
+    Ok(toml::Value::Table(table))
+}
+
+fn provider_model_config_to_value(config: &ProviderModelConfig) -> anyhow::Result<toml::Value> {
+    let mut table = provider_settings_to_table(&config.settings)?;
+    if !config.params.is_empty() {
+        table.insert("params".to_string(), toml::Value::try_from(&config.params)?);
+    }
+    Ok(toml::Value::Table(table))
+}
+
+fn provider_settings_to_table(settings: &ProviderSettings) -> anyhow::Result<toml::Table> {
+    let mut table = toml::Table::new();
+    if let Some(value) = &settings.output_format {
+        table.insert(
+            "output_format".to_string(),
+            toml::Value::String(value.clone()),
+        );
+    }
+    if let Some(value) = settings.timeout_secs {
+        table.insert("timeout_secs".to_string(), toml::Value::try_from(value)?);
+    }
+    if let Some(value) = &settings.command {
+        table.insert("command".to_string(), toml::Value::String(value.clone()));
+    }
+    if let Some(value) = &settings.endpoint {
+        table.insert("endpoint".to_string(), toml::Value::String(value.clone()));
+    }
+    if let Some(value) = &settings.model {
+        table.insert("model".to_string(), toml::Value::String(value.clone()));
+    }
+    if let Some(value) = &settings.api_key_env {
+        table.insert(
+            "api_key_env".to_string(),
+            toml::Value::String(value.clone()),
+        );
+    }
+    if let Some(value) = &settings.display_name {
+        table.insert(
+            "display_name".to_string(),
+            toml::Value::String(value.clone()),
+        );
+    }
+    Ok(table)
+}
+
+pub fn validate_config(config: &OsttConfig) -> anyhow::Result<()> {
+    for (provider_id, provider_config) in &config.provider_configs {
+        if crate::transcription::TranscriptionProvider::from_id(provider_id).is_none() {
+            anyhow::bail!("Unknown provider config '{}'.", provider_id);
+        }
+
+        for model_id in provider_config.models.keys() {
+            validate_model_id(provider_id, model_id)?;
+        }
+    }
+
+    if config.transcription.provider.as_deref() == Some("local") {
+        anyhow::bail!("Provider 'local' is no longer supported. Use provider = \"whisper\".");
+    }
+
+    Ok(())
+}
+
+pub fn resolve_output_format(
+    config: &OsttConfig,
+    selected_model: &crate::config::SelectedModel,
+) -> String {
+    if let Some(output_format) = config
+        .provider_configs
+        .get(&selected_model.provider_id)
+        .and_then(|provider| provider.models.get(&selected_model.model_id))
+        .and_then(|model| model.settings.output_format.as_deref())
+    {
+        return output_format.to_string();
+    }
+
+    if let Some(output_format) = config
+        .provider_configs
+        .get(&selected_model.provider_id)
+        .and_then(|provider| provider.settings.output_format.as_deref())
+    {
+        return output_format.to_string();
+    }
+
+    if selected_model.provider_id == "whisper" {
+        return LOCAL_TRANSCRIPTION_OUTPUT_FORMAT.to_string();
+    }
+
+    config.audio.output_format.clone()
 }
 
 /// Retrieves the path to the config file.
@@ -622,51 +998,52 @@ pub fn save_config(config: &OsttConfig) -> anyhow::Result<()> {
     config.save()
 }
 
-pub fn validate_model_options(model_options: &ModelOptionsConfig) -> anyhow::Result<()> {
-    for (full_model_id, options) in model_options {
-        let (provider_id, model_id) = full_model_id.split_once('/').ok_or_else(|| {
-            anyhow::anyhow!(
-                "Invalid model_options key '{}'. Use 'provider/model'.",
-                full_model_id
-            )
-        })?;
-
-        if provider_id != "local" && model::find_model(provider_id, model_id).is_none() {
-            anyhow::bail!(
-                "Invalid model_options key '{}'. Unknown provider/model.",
-                full_model_id
-            );
-        }
-
-        if provider_id == "local" && !crate::transcription::local_models::is_safe_model_id(model_id)
-        {
-            anyhow::bail!(
-                "Invalid model_options key '{}'. Local model id must contain only lowercase letters, digits, '.', '_' or '-'.",
-                full_model_id
-            );
-        }
-
-        let schema = api::option_schema(provider_id, model_id).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Invalid model_options key '{}'. No options are supported for this model.",
-                full_model_id
-            )
-        })?;
-
-        for (option_name, value) in options {
-            let Some(spec) = schema.option(option_name) else {
-                anyhow::bail!(
-                    "Invalid option '{}' for '{}'. Supported options: {}.",
-                    option_name,
-                    full_model_id,
-                    schema.option_names().join(", ")
-                );
-            };
-            validate_model_option_type(full_model_id, option_name, value, spec.kind)?;
-        }
-
-        api::validate_model_options(provider_id, full_model_id, options)?;
+pub fn validate_model_id(provider_id: &str, model_id: &str) -> anyhow::Result<()> {
+    if provider_id != "whisper" && model::find_model(provider_id, model_id).is_none() {
+        anyhow::bail!(
+            "Unknown model '{}' for provider '{}'. Please run 'ostt model' to select a supported model.",
+            model_id,
+            provider_id
+        );
     }
+
+    if provider_id == "whisper" && !crate::transcription::local_models::is_safe_model_id(model_id) {
+        anyhow::bail!(
+            "Whisper model id '{}' must contain only lowercase letters, digits, '.', '_' or '-'.",
+            model_id
+        );
+    }
+
+    Ok(())
+}
+
+pub fn validate_params_for_model(
+    provider_id: &str,
+    model_id: &str,
+    params: &ParamsConfig,
+) -> anyhow::Result<()> {
+    validate_model_id(provider_id, model_id)?;
+    let full_model_id = format!("{provider_id}/{model_id}");
+    let schema = api::option_schema(provider_id, model_id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Invalid params for '{}'. No params are supported for this model.",
+            full_model_id
+        )
+    })?;
+
+    for (option_name, value) in params {
+        let Some(spec) = schema.option(option_name) else {
+            anyhow::bail!(
+                "Invalid param '{}' for '{}'. Supported params: {}.",
+                option_name,
+                full_model_id,
+                schema.option_names().join(", ")
+            );
+        };
+        validate_model_option_type(&full_model_id, option_name, value, spec.kind)?;
+    }
+
+    api::validate_params(provider_id, &full_model_id, params)?;
 
     Ok(())
 }
@@ -719,7 +1096,7 @@ fn validate_model_option_type(
 
     if !matches {
         anyhow::bail!(
-            "Invalid value for option '{}' in '{}'. Expected {}.",
+            "Invalid value for param '{}' in '{}'. Expected {}.",
             option_name,
             full_model_id,
             expected.name()
@@ -728,7 +1105,7 @@ fn validate_model_option_type(
 
     if matches_empty_string(expected, value) {
         anyhow::bail!(
-            "Invalid value for option '{}' in '{}'. Value must not be empty.",
+            "Invalid value for param '{}' in '{}'. Value must not be empty.",
             option_name,
             full_model_id,
         );
@@ -744,68 +1121,6 @@ fn matches_empty_string(expected: model::ModelOptionKind, value: &ModelOptionVal
         (model::ModelOptionKind::StringOrStringList, ModelOptionValue::String(s)) => s.is_empty(),
         _ => false,
     }
-}
-
-pub fn ensure_local_transcription_audio_config() -> anyhow::Result<()> {
-    let config_path = get_config_path()?;
-    let content = fs::read_to_string(&config_path)?;
-    let updated = ensure_local_transcription_audio_config_content(&content);
-    fs::write(config_path, updated)?;
-    Ok(())
-}
-
-fn ensure_local_transcription_audio_config_content(content: &str) -> String {
-    let mut output = Vec::new();
-    let mut in_audio = false;
-    let mut saw_audio = false;
-    let mut wrote_output_format = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed == "[audio]" {
-            in_audio = true;
-            saw_audio = true;
-            wrote_output_format = false;
-            output.push(line.to_string());
-            continue;
-        }
-
-        if in_audio && trimmed.starts_with('[') && trimmed.ends_with(']') {
-            if !wrote_output_format {
-                output.push(format!(
-                    "output_format = \"{LOCAL_TRANSCRIPTION_OUTPUT_FORMAT}\""
-                ));
-            }
-            in_audio = false;
-        }
-
-        if in_audio && trimmed.starts_with("sample_rate") {
-            continue;
-        } else if in_audio && trimmed.starts_with("output_format") {
-            output.push(format!(
-                "output_format = \"{LOCAL_TRANSCRIPTION_OUTPUT_FORMAT}\""
-            ));
-            wrote_output_format = true;
-        } else {
-            output.push(line.to_string());
-        }
-    }
-
-    if in_audio {
-        if !wrote_output_format {
-            output.push(format!(
-                "output_format = \"{LOCAL_TRANSCRIPTION_OUTPUT_FORMAT}\""
-            ));
-        }
-    } else if !saw_audio {
-        output.push(String::new());
-        output.push("[audio]".to_string());
-        output.push(format!(
-            "output_format = \"{LOCAL_TRANSCRIPTION_OUTPUT_FORMAT}\""
-        ));
-    }
-
-    format!("{}\n", output.join("\n").trim())
 }
 
 #[cfg(test)]
@@ -842,30 +1157,6 @@ mod tests {
         assert!(!is_local_transcription_audio_compatible(&audio));
     }
 
-    #[test]
-    fn local_transcription_audio_update_preserves_other_config() {
-        let content = r#"# ostt
-[audio]
-device = "default"
-peak_volume_threshold = 90
-output_format = "mp3 -ab 16k -ar 12000"
-visualization = "spectrum"
-
-[transcription]
-provider = "openai"
-model = "whisper-1"
-"#;
-
-        let updated = ensure_local_transcription_audio_config_content(content);
-
-        assert!(updated.contains("device = \"default\""));
-        assert!(!updated.contains("sample_rate"));
-        assert!(updated.contains("peak_volume_threshold = 90"));
-        assert!(updated.contains("output_format = \"pcm_s16le -ar 16000\""));
-        assert!(updated.contains("[transcription]"));
-        assert!(updated.contains("provider = \"openai\""));
-    }
-
     fn validate_process_config(config: &ProcessConfig) -> Result<(), Box<dyn std::error::Error>> {
         for action in &config.actions {
             action.validate()?;
@@ -874,8 +1165,7 @@ model = "whisper-1"
     }
 
     fn validate_ostt_config(config: &OsttConfig) -> anyhow::Result<()> {
-        config.providers.local.validate()?;
-        validate_model_options(&config.model_options)?;
+        validate_config(config)?;
         for action in &config.process.actions {
             action
                 .validate()
@@ -981,29 +1271,30 @@ model = "whisper-1"
     }
 
     #[test]
-    fn missing_local_provider_defaults_to_standard_local_params() {
+    fn missing_whisper_provider_uses_builtin_output_format_default() {
         let toml_str = r#"
             [audio]
             device = "default"
         "#;
 
         let config = parse_ostt_config(toml_str).unwrap();
-        let local = &config.providers.local;
-        assert_eq!(local.language, "auto");
-        assert!(local.no_timestamps);
-        assert!(local.no_context);
-        assert_eq!(local.temperature, 0.0);
-        assert_eq!(local.entropy_thold, 2.4);
-        assert_eq!(local.no_speech_thold, 0.6);
+        let selected = crate::config::SelectedModel {
+            provider_id: "whisper".to_string(),
+            model_id: "turbo".to_string(),
+        };
+        assert_eq!(
+            resolve_output_format(&config, &selected),
+            "pcm_s16le -ar 16000"
+        );
     }
 
     #[test]
-    fn full_local_provider_deserializes() {
+    fn full_whisper_params_deserialize() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [providers.local]
+            [whisper.params]
             language = "sv"
             no_timestamps = false
             no_context = false
@@ -1013,13 +1304,16 @@ model = "whisper-1"
         "#;
 
         let config = parse_ostt_config(toml_str).unwrap();
-        let local = &config.providers.local;
-        assert_eq!(local.language, "sv");
-        assert!(!local.no_timestamps);
-        assert!(!local.no_context);
-        assert_eq!(local.temperature, 0.2);
-        assert_eq!(local.entropy_thold, 3.0);
-        assert_eq!(local.no_speech_thold, 0.4);
+        let params = &config.provider_configs["whisper"].params;
+        assert_eq!(
+            params["language"],
+            ModelOptionValue::String("sv".to_string())
+        );
+        assert_eq!(params["no_timestamps"], ModelOptionValue::Bool(false));
+        assert_eq!(params["no_context"], ModelOptionValue::Bool(false));
+        assert_eq!(params["temperature"], ModelOptionValue::Number(0.2));
+        assert_eq!(params["entropy_thold"], ModelOptionValue::Number(3.0));
+        assert_eq!(params["no_speech_thold"], ModelOptionValue::Number(0.4));
     }
 
     #[test]
@@ -1037,12 +1331,11 @@ model = "whisper-1"
                     [audio]
                     device = "default"
 
-                    [providers.local]
+                    [whisper.turbo.params]
                     {local_setting}
                 "#
             );
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            let err = parse_ostt_config(&toml_str).unwrap_err().to_string();
             assert!(
                 err.contains(expected_error),
                 "expected '{err}' to contain '{expected_error}'"
@@ -1056,7 +1349,7 @@ model = "whisper-1"
             [audio]
             device = "default"
 
-            [providers.local]
+            [whisper.params]
             temperature = 1.0
             entropy_thold = 0.0
             no_speech_thold = 0.0
@@ -1067,12 +1360,12 @@ model = "whisper-1"
     }
 
     #[test]
-    fn model_options_validate_against_model_schema() {
+    fn params_validate_against_model_schema() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [model_options."deepgram/nova-3"]
+            [deepgram.nova-3.params]
             detect_language = ["sv", "en"]
             smart_format = true
             keyterm = ["OSTT"]
@@ -1083,12 +1376,12 @@ model = "whisper-1"
     }
 
     #[test]
-    fn model_options_allow_local_whisper_options_per_model() {
+    fn params_allow_whisper_params_per_model() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [model_options."local/tiny"]
+            [whisper.tiny.params]
             language = "sv"
             no_timestamps = true
             no_context = false
@@ -1096,7 +1389,7 @@ model = "whisper-1"
             entropy_thold = 2.4
             no_speech_thold = 0.6
 
-            [model_options."local/turbo"]
+            [whisper.turbo.params]
             language = "en"
             temperature = 0.2
         "#;
@@ -1106,7 +1399,7 @@ model = "whisper-1"
     }
 
     #[test]
-    fn model_options_reject_invalid_local_whisper_values() {
+    fn params_reject_invalid_whisper_values() {
         let cases = [
             ("temperature = 1.5", "Expected 0-1"),
             ("entropy_thold = -1.0", "Expected >= 0"),
@@ -1119,424 +1412,95 @@ model = "whisper-1"
                     [audio]
                     device = "default"
 
-                    [model_options."local/turbo"]
+                    [whisper.turbo.params]
                     {setting}
                 "#
             );
 
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
+            let err = parse_ostt_config(&toml_str).unwrap_err().to_string();
             assert!(err.contains(expected), "{err}");
         }
     }
 
     #[test]
-    fn model_options_reject_unsafe_local_model_id() {
+    fn params_reject_unsafe_whisper_model_id() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [model_options."local/Turbo"]
+            [whisper.Turbo.params]
             language = "en"
         "#;
 
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("Local model id"));
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("Whisper model id"));
     }
 
     #[test]
-    fn model_options_reject_wrong_value_types() {
+    fn params_reject_wrong_value_types() {
         let cases = [
             (
-                "deepgram/nova-3",
+                "[deepgram.nova-3.params]",
                 "smart_format = \"true\"",
                 "smart_format",
                 "boolean",
             ),
             (
-                "openai/gpt-4o-transcribe",
+                "[openai.gpt-4o-transcribe.params]",
                 "temperature = \"0.2\"",
                 "temperature",
                 "number",
             ),
             (
-                "openai/gpt-4o-transcribe",
+                "[openai.gpt-4o-transcribe.params]",
                 "prompt = [\"OSTT\"]",
                 "prompt",
                 "string",
             ),
             (
-                "deepgram/nova-3",
+                "[deepgram.nova-3.params]",
                 "keyterm = \"OSTT\"",
                 "keyterm",
                 "string list",
             ),
             (
-                "elevenlabs/scribe_v2",
+                "[elevenlabs.scribe_v2.params]",
                 "num_speakers = \"2\"",
                 "num_speakers",
                 "integer",
             ),
         ];
 
-        for (model_id, setting, option_name, expected_type) in cases {
+        for (header, setting, param_name, expected_type) in cases {
             let toml_str = format!(
                 r#"
                     [audio]
                     device = "default"
 
-                    [model_options."{model_id}"]
+                    {header}
                     {setting}
                 "#
             );
 
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(option_name), "{err}");
+            let err = parse_ostt_config(&toml_str).unwrap_err().to_string();
+            assert!(err.contains(param_name), "{err}");
             assert!(err.contains(expected_type), "{err}");
         }
     }
 
     #[test]
-    fn model_options_accept_bool_or_string_list_shapes() {
+    fn params_parse_quoted_model_ids_with_slashes() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [model_options."deepgram/nova-3"]
-            detect_language = true
-
-            [model_options."deepgram/nova-2"]
-            detect_language = ["en", "sv"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_invalid_bool_or_string_list_shape() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."deepgram/nova-3"]
-            detect_language = "en,sv"
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("detect_language"));
-        assert!(err.contains("boolean or string list"));
-    }
-
-    #[test]
-    fn model_options_reject_duplicate_config_keys_at_parse_time() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."deepgram/nova-3"]
-            smart_format = true
-            smart_format = false
-        "#;
-
-        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
-        assert!(err.contains("duplicate key") || err.contains("duplicate field"));
-    }
-
-    #[test]
-    fn model_options_reject_unknown_option_for_model() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."openai/gpt-4o-transcribe"]
-            smart_format = true
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("Invalid option 'smart_format'"));
-    }
-
-    #[test]
-    fn model_options_allow_openai_documented_json_safe_options() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."openai/gpt-4o-transcribe"]
-            include = ["logprobs"]
-
-            [model_options."openai/whisper-1"]
-            response_format = "verbose_json"
-            timestamp_granularities = ["word", "segment"]
-
-            [model_options."openai/gpt-4o-transcribe-diarize"]
-            response_format = "diarized_json"
-            chunking_strategy = "auto"
-            known_speaker_names = ["agent"]
-            known_speaker_references = ["data:audio/wav;base64,AAA..."]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_openai_options_that_break_json_parsing_or_api_rules() {
-        let cases = [
-            (
-                "openai/gpt-4o-transcribe",
-                "include = [\"timestamps\"]",
-                "include",
-            ),
-            (
-                "openai/whisper-1",
-                "response_format = \"srt\"",
-                "response_format",
-            ),
-            (
-                "openai/whisper-1",
-                "timestamp_granularities = [\"sentence\"]",
-                "timestamp_granularities",
-            ),
-            (
-                "openai/whisper-1",
-                "response_format = \"json\"\ntimestamp_granularities = [\"word\"]",
-                "verbose_json",
-            ),
-            (
-                "openai/gpt-4o-transcribe-diarize",
-                "chunking_strategy = \"none\"",
-                "chunking_strategy",
-            ),
-        ];
-
-        for (model_id, setting, expected) in cases {
-            let toml_str = format!(
-                r#"
-                    [audio]
-                    device = "default"
-
-                    [model_options."{model_id}"]
-                    {setting}
-                "#
-            );
-
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(expected), "{err}");
-        }
-    }
-
-    #[test]
-    fn model_options_reject_model_specific_deepgram_keyterm() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."deepgram/nova-2"]
-            keyterm = ["OSTT"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("Invalid option 'keyterm'"));
-    }
-
-    #[test]
-    fn model_options_allow_deepgram_nova_2_keywords() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."deepgram/nova-2"]
-            keywords = ["OSTT"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_model_specific_elevenlabs_v2_option_on_v1() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."elevenlabs/scribe_v1"]
-            no_verbatim = true
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("Invalid option 'no_verbatim'"));
-    }
-
-    #[test]
-    fn model_options_allow_elevenlabs_documented_options() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."elevenlabs/scribe_v2"]
-            language_code = "en"
-            tag_audio_events = true
-            timestamps_granularity = "word"
-            diarize = true
-            detect_speaker_roles = true
-            diarization_threshold = 0.2
-            temperature = 1.5
-            file_format = "other"
-            seed = 42
-            use_multi_channel = false
-            keyterms = ["OSTT"]
-            no_verbatim = true
-            entity_detection = ["pii", "phi"]
-            entity_redaction = "pii"
-            entity_redaction_mode = "enumerated_entity_type"
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_invalid_elevenlabs_values() {
-        let cases = [
-            (
-                "timestamps_granularity = \"sentence\"",
-                "timestamps_granularity",
-            ),
-            ("file_format = \"wav\"", "file_format"),
-            (
-                "entity_redaction_mode = \"masked\"",
-                "entity_redaction_mode",
-            ),
-            (
-                "diarize = false\ndiarization_threshold = 0.2",
-                "diarization_threshold requires diarize",
-            ),
-            (
-                "diarize = true\nnum_speakers = 2\ndiarization_threshold = 0.2",
-                "diarization_threshold cannot be used with num_speakers",
-            ),
-            (
-                "detect_speaker_roles = true",
-                "detect_speaker_roles requires diarize",
-            ),
-            (
-                "diarize = true\ndetect_speaker_roles = true\nuse_multi_channel = true",
-                "detect_speaker_roles cannot be used with use_multi_channel",
-            ),
-        ];
-
-        for (setting, expected) in cases {
-            let toml_str = format!(
-                r#"
-                    [audio]
-                    device = "default"
-
-                    [model_options."elevenlabs/scribe_v2"]
-                    {setting}
-                "#
-            );
-
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(expected), "{err}");
-        }
-    }
-
-    #[test]
-    fn model_options_reject_berget_only_hotwords_on_groq() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."groq/whisper-large-v3"]
-            hotwords = ["OSTT"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("Invalid option 'hotwords'"));
-    }
-
-    #[test]
-    fn model_options_allow_berget_openapi_options() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."berget/KBLab/kb-whisper-large"]
+            [berget."openai/whisper-large-v3".params]
             language = "sv"
             hotwords = ["OSTT", "Berget"]
             prompt = "Swedish technical dictation."
             temperature = 0.0
-            response_format = "verbose_json"
-            timestamp_granularities = ["word", "segment"]
-            align = true
-            diarize = true
-            speaker_embeddings = true
-            chunk_size = 30
-            batch_size = 8
-        "#;
 
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_invalid_berget_values() {
-        let cases = [
-            ("response_format = \"srt\"", "response_format"),
-            (
-                "timestamp_granularities = [\"sentence\"]",
-                "timestamp_granularities",
-            ),
-            ("chunk_size = 0", "chunk_size"),
-            ("chunk_size = 61", "chunk_size"),
-            ("batch_size = 0", "batch_size"),
-            ("batch_size = 33", "batch_size"),
-            ("stream = true", "Invalid option 'stream'"),
-        ];
-
-        for (setting, expected) in cases {
-            let toml_str = format!(
-                r#"
-                    [audio]
-                    device = "default"
-
-                    [model_options."berget/openai/whisper-large-v3"]
-                    {setting}
-                "#
-            );
-
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(expected), "{err}");
-        }
-    }
-
-    #[test]
-    fn model_options_allow_deepinfra_documented_options_and_models() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."deepinfra/openai/whisper-large-v3-turbo"]
-            task = "transcribe"
-            initial_prompt = "Names: OSTT, DeepInfra, Whisper."
-            language = "en"
-            temperature = 0.0
-            chunk_level = "word"
-            chunk_length_s = 30
-
-            [model_options."deepinfra/mistralai/Voxtral-Mini-3B-2507"]
+            [deepinfra."mistralai/Voxtral-Mini-3B-2507".params]
             task = "transcribe"
         "#;
 
@@ -1545,230 +1509,87 @@ model = "whisper-1"
     }
 
     #[test]
-    fn model_options_reject_invalid_deepinfra_values() {
-        let cases = [
-            ("task = \"summarize\"", "task"),
-            ("chunk_level = \"sentence\"", "chunk_level"),
-            ("chunk_length_s = 31", "chunk_length_s"),
-            ("prompt = \"OSTT\"", "Invalid option 'prompt'"),
-        ];
-
-        for (setting, expected) in cases {
-            let toml_str = format!(
-                r#"
-                    [audio]
-                    device = "default"
-
-                    [model_options."deepinfra/openai/whisper-large-v3"]
-                    {setting}
-                "#
-            );
-
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(expected), "{err}");
-        }
-    }
-
-    #[test]
-    fn model_options_allow_groq_documented_json_safe_options() {
+    fn params_reject_unknown_param_for_model() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [model_options."groq/whisper-large-v3-turbo"]
-            response_format = "verbose_json"
-            timestamp_granularities = ["word", "segment"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_groq_options_that_break_json_parsing_or_api_rules() {
-        let cases = [
-            ("response_format = \"text\"", "response_format"),
-            (
-                "timestamp_granularities = [\"sentence\"]",
-                "timestamp_granularities",
-            ),
-            (
-                "response_format = \"json\"\ntimestamp_granularities = [\"word\"]",
-                "verbose_json",
-            ),
-        ];
-
-        for (setting, expected) in cases {
-            let toml_str = format!(
-                r#"
-                    [audio]
-                    device = "default"
-
-                    [model_options."groq/whisper-large-v3"]
-                    {setting}
-                "#
-            );
-
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(expected), "{err}");
-        }
-    }
-
-    #[test]
-    fn model_options_allow_mistral_documented_options() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."mistral/voxtral-mini-latest"]
-            language = "sv"
-            diarize = true
-            context_bias = ["OSTT"]
-            temperature = 0.2
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_allow_mistral_timestamp_granularities() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."mistral/voxtral-mini-latest"]
-            context_bias = ["OSTT"]
-            diarize = true
-            timestamp_granularities = ["word"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
-    }
-
-    #[test]
-    fn model_options_reject_invalid_mistral_values() {
-        let cases = [
-            (
-                "timestamp_granularities = [\"sentence\"]",
-                "timestamp_granularities",
-            ),
-            (
-                "language = \"en\"\ntimestamp_granularities = [\"word\"]",
-                "not compatible with language",
-            ),
-        ];
-
-        for (setting, expected) in cases {
-            let toml_str = format!(
-                r#"
-                    [audio]
-                    device = "default"
-
-                    [model_options."mistral/voxtral-mini-latest"]
-                    {setting}
-                "#
-            );
-
-            let config = parse_ostt_config(&toml_str).unwrap();
-            let err = validate_ostt_config(&config).unwrap_err().to_string();
-            assert!(err.contains(expected), "{err}");
-        }
-    }
-
-    #[test]
-    fn model_options_reject_assemblyai_prompt_with_keyterms_prompt() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."assemblyai/universal-3-pro"]
-            prompt = "Use Swedish spelling."
-            keyterms_prompt = ["OSTT"]
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("prompt"));
-        assert!(err.contains("keyterms_prompt"));
-    }
-
-    #[test]
-    fn model_options_reject_out_of_range_values() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."openai/gpt-4o-transcribe"]
-            temperature = 1.5
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("Expected 0-1"));
-    }
-
-    #[test]
-    fn model_options_reject_empty_string_for_string_typed_option() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."openai/gpt-4o-transcribe"]
-            prompt = ""
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("prompt"));
-        assert!(err.contains("must not be empty"));
-    }
-
-    #[test]
-    fn model_options_reject_empty_string_for_bool_or_string_option() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [model_options."deepgram/nova-3"]
-            language = ""
-        "#;
-
-        let config = parse_ostt_config(toml_str).unwrap();
-        let err = validate_ostt_config(&config).unwrap_err().to_string();
-        assert!(err.contains("language"));
-        assert!(err.contains("must not be empty"));
-    }
-
-    #[test]
-    fn old_provider_level_request_options_fail_deserialization() {
-        let toml_str = r#"
-            [audio]
-            device = "default"
-
-            [providers.deepgram]
+            [openai.gpt-4o-transcribe.params]
             smart_format = true
         "#;
 
         let err = parse_ostt_config(toml_str).unwrap_err().to_string();
-        assert!(err.contains("unknown field `deepgram`"));
+        assert!(err.contains("Invalid param 'smart_format'"));
     }
 
     #[test]
-    fn local_config_validation_does_not_validate_active_model_id() {
+    fn deprecated_providers_section_fails_deserialization() {
         let toml_str = r#"
             [audio]
             device = "default"
 
-            [providers.local]
-            language = "auto"
+            [providers]
         "#;
 
-        let config = parse_ostt_config(toml_str).unwrap();
-        validate_ostt_config(&config).unwrap();
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("Deprecated config section '[providers]'"));
+    }
+
+    #[test]
+    fn deprecated_model_options_section_fails_deserialization() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [model_options]
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("Deprecated config section '[model_options]'"));
+    }
+
+    #[test]
+    fn deprecated_audio_sample_rate_fails_deserialization() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+            sample_rate = 16000
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("Deprecated config key '[audio].sample_rate'"));
+    }
+
+    #[test]
+    fn deprecated_process_actions_array_fails_deserialization() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [[process.actions]]
+            id = "clean"
+            name = "Clean up"
+            type = "bash"
+            command = "cat"
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("Deprecated config table '[[process.actions]]'"));
+    }
+
+    #[test]
+    fn deprecated_local_provider_selection_fails_validation() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [transcription]
+            provider = "local"
+            model = "turbo"
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+        assert!(err.contains("Provider 'local' is no longer supported"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,8 +14,9 @@ pub use file::{
     ProcessConfig,
 };
 pub use file::{
-    AudioConfig, ModelOptionValue, ModelOptionsConfig, OsttConfig, PopupConfig, ProvidersConfig,
-    TranscriptionSelectionConfig, VisualizationType,
+    AudioConfig, ModelOptionValue, OsttConfig, ParamsConfig, PopupConfig, ProviderConfig,
+    ProviderConfigs, ProviderModelConfig, ProviderSettings, TranscriptionSelectionConfig,
+    VisualizationType,
 };
 pub use secrets::{
     clear_api_key, clear_selected_model, get_api_key, get_authorized_providers, get_selected_model,
@@ -23,6 +24,4 @@ pub use secrets::{
     SelectedModel,
 };
 
-pub use file::{
-    ensure_local_transcription_audio_config, is_local_transcription_audio_compatible, save_config,
-};
+pub use file::{is_local_transcription_audio_compatible, resolve_output_format, save_config};

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -26,6 +26,10 @@ pub fn parse_provider_model(value: &str) -> anyhow::Result<SelectedModel> {
         anyhow::bail!("Expected model in PROVIDER/MODEL format, for example deepgram/nova-3");
     }
 
+    if provider_id == "local" {
+        anyhow::bail!("Provider 'local' is no longer supported. Use 'whisper/{model_id}'.");
+    }
+
     let provider = TranscriptionProvider::from_id(provider_id);
     if provider.is_none() {
         anyhow::bail!(
@@ -35,7 +39,8 @@ pub fn parse_provider_model(value: &str) -> anyhow::Result<SelectedModel> {
         );
     }
 
-    if provider != Some(TranscriptionProvider::Local) && find_model(provider_id, model_id).is_none()
+    if provider != Some(TranscriptionProvider::Whisper)
+        && find_model(provider_id, model_id).is_none()
     {
         anyhow::bail!(
             "Unknown model '{}' for provider '{}'. Please run 'ostt model' to select a supported model.",

--- a/src/model/cloud_model_view.rs
+++ b/src/model/cloud_model_view.rs
@@ -158,7 +158,7 @@ pub(crate) fn build_cloud_provider_sections(
 
     TranscriptionProvider::all()
         .iter()
-        .filter(|provider| **provider != TranscriptionProvider::Local)
+        .filter(|provider| **provider != TranscriptionProvider::Whisper)
         .filter(|provider| authorized.contains(provider.id()))
         .filter_map(|provider| {
             let models: Vec<CloudModelEntry> = transcription::models_for_provider(provider)

--- a/src/model/local_model_view/mod.rs
+++ b/src/model/local_model_view/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) mod custom_model_details_dialog;
 pub(crate) mod custom_model_url_input_dialog;
-pub(crate) mod local_model_audio_config_confirmation_dialog;
 pub(crate) mod local_model_delete_confirmation_dialog;
 pub(crate) mod local_model_download_confirmation_dialog;
 pub(crate) mod local_model_download_progress_dialog;
@@ -32,7 +31,6 @@ use crate::ui::{render_error_dialog, render_toast, DialogAction, Toast};
 
 use custom_model_details_dialog::CustomModelDetailsDialog;
 use custom_model_url_input_dialog::CustomModelUrlInputDialog;
-use local_model_audio_config_confirmation_dialog::LocalModelAudioConfigConfirmationDialog;
 use local_model_delete_confirmation_dialog::LocalModelDeleteConfirmationDialog;
 use local_model_download_confirmation_dialog::LocalModelDownloadConfirmationDialog;
 use local_model_download_progress_dialog::LocalModelDownloadProgressDialog;
@@ -135,13 +133,6 @@ fn render_local_models(frame: &mut Frame<'_>, tui: &LocalModelsTui) {
             LocalModelListView::render(frame, tui);
             LocalModelDownloadConfirmationDialog::render(frame, entry, *selected_action);
         }
-        LocalModelsMode::ConfirmAudioConfig {
-            entry,
-            selected_action,
-        } => {
-            LocalModelListView::render(frame, tui);
-            LocalModelAudioConfigConfirmationDialog::render(frame, entry, *selected_action);
-        }
         LocalModelsMode::CustomModelInput {
             input,
             selected_action,
@@ -199,7 +190,7 @@ fn build_local_model_entries(
         .map(|entry| {
             let is_downloaded = model_destination(entry).exists();
             let is_active = selected_model
-                .map(|selected| selected.provider_id == "local" && selected.model_id == entry.id)
+                .map(|selected| selected.provider_id == "whisper" && selected.model_id == entry.id)
                 .unwrap_or(false);
             let is_daemon_loaded = daemon_model_id == Some(entry.id.as_str());
 
@@ -357,17 +348,6 @@ async fn handle_key(
             start_confirmed_download(tui, running_download, &entry);
         }
         (
-            LocalModelsMode::ConfirmAudioConfig { .. },
-            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N'),
-        ) => tui.back_to_browse(),
-        (LocalModelsMode::ConfirmAudioConfig { entry, .. }, KeyCode::Enter) => {
-            update_audio_config_and_activate(tui, registry, &entry).await?;
-        }
-        (
-            LocalModelsMode::ConfirmAudioConfig { entry, .. },
-            KeyCode::Char('y') | KeyCode::Char('Y'),
-        ) => update_audio_config_and_activate(tui, registry, &entry).await?,
-        (
             LocalModelsMode::ConfirmDelete { .. },
             KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N'),
         ) => tui.back_to_browse(),
@@ -405,19 +385,6 @@ async fn handle_selected_entry(
         return Ok(());
     }
 
-    let config = config::OsttConfig::load().map_err(|error| anyhow::anyhow!(error.to_string()))?;
-    if !config::is_local_transcription_audio_compatible(&config.audio) {
-        tracing::debug!(
-            "Confirming audio config update before activating local model '{}'",
-            entry.id
-        );
-        tui.mode = LocalModelsMode::ConfirmAudioConfig {
-            entry,
-            selected_action: DialogAction::Ok,
-        };
-        return Ok(());
-    }
-
     match activate_entry(&entry).await {
         Ok(()) => {
             tracing::info!("Activated local model '{}'", entry.id);
@@ -440,40 +407,8 @@ async fn activate_entry(entry: &LocalModelEntry) -> anyhow::Result<()> {
     if !path.exists() {
         anyhow::bail!("Download first with [d]");
     }
-    config::save_selected_model("local", &entry.id)?;
+    config::save_selected_model("whisper", &entry.id)?;
     reload_daemon_if_running(&entry.id).await?;
-    Ok(())
-}
-
-async fn update_audio_config_and_activate(
-    tui: &mut LocalModelsTui,
-    registry: &[RegistryEntry],
-    entry: &LocalModelEntry,
-) -> anyhow::Result<()> {
-    match async {
-        config::ensure_local_transcription_audio_config()?;
-        activate_entry(entry).await
-    }
-    .await
-    {
-        Ok(()) => {
-            tracing::info!(
-                "Updated audio config and activated local model '{}'",
-                entry.id
-            );
-            tui.back_to_browse();
-            tui.toast = Some(Toast::success(format!("Activated {}", entry.name)));
-            tui.refresh(&load_state(), registry)?;
-        }
-        Err(error) => {
-            tracing::error!(
-                "Failed to update audio config for local model '{}': {}",
-                entry.id,
-                error
-            );
-            tui.toast = Some(Toast::error(error.to_string()));
-        }
-    }
     Ok(())
 }
 
@@ -720,7 +655,7 @@ fn delete_entry(entry: &LocalModelEntry) -> anyhow::Result<()> {
     let path = model_destination(&registry_entry_from_model(entry));
     std::fs::remove_file(&path)?;
     if config::get_selected_model_entry()?
-        .is_some_and(|selected| selected.provider_id == "local" && selected.model_id == entry.id)
+        .is_some_and(|selected| selected.provider_id == "whisper" && selected.model_id == entry.id)
     {
         config::clear_selected_model()?;
     }
@@ -874,7 +809,7 @@ mod tests {
             fs::create_dir_all(model_files_dir()).expect("create files dir");
             fs::write(model_files_dir().join("turbo.bin"), [1, 2, 3]).expect("write model");
             let selected = SelectedModel {
-                provider_id: "local".to_string(),
+                provider_id: "whisper".to_string(),
                 model_id: "turbo".to_string(),
             };
 

--- a/src/model/local_model_view/types.rs
+++ b/src/model/local_model_view/types.rs
@@ -60,10 +60,6 @@ pub(crate) enum LocalModelsMode {
         entry: LocalModelEntry,
         selected_action: DialogAction,
     },
-    ConfirmAudioConfig {
-        entry: LocalModelEntry,
-        selected_action: DialogAction,
-    },
     ErrorDialog {
         message: String,
         return_mode: Box<LocalModelsMode>,

--- a/src/setup/version.rs
+++ b/src/setup/version.rs
@@ -1,4 +1,4 @@
-//! Version comparison and migration logic.
+//! Version comparison and config version maintenance.
 //!
 //! Handles checking if setup is needed by comparing embedded version with config file version.
 
@@ -95,7 +95,7 @@ fn read_config_version_from_file(config_path: &Path) -> anyhow::Result<Option<St
 /// 3. Config file version is older than current version
 ///
 /// Returns the version that the config file was at. Callers decide whether to
-/// create the default config, run migrations, or only update `config_version`.
+/// create the default config or update `config_version`.
 pub fn check_setup_needed(config_path: &Path) -> anyhow::Result<Option<String>> {
     if !config_path.exists() {
         // Config doesn't exist — setup is needed (fresh install)
@@ -161,10 +161,6 @@ pub fn update_config_version(config_path: &Path) -> anyhow::Result<()> {
     };
 
     std::fs::write(config_path, new_content)?;
-    Ok(())
-}
-
-pub fn run_config_migrations(_config_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -101,7 +101,7 @@ pub(super) fn validate_options(
 
     if options.contains_key("prompt") && options.contains_key("keyterms_prompt") {
         anyhow::bail!(
-            "Invalid options for '{}'. AssemblyAI does not allow 'prompt' and 'keyterms_prompt' together.",
+            "Invalid params for '{}'. AssemblyAI does not allow 'prompt' and 'keyterms_prompt' together.",
             full_model_id
         );
     }

--- a/src/transcription/api/deepgram.rs
+++ b/src/transcription/api/deepgram.rs
@@ -139,7 +139,7 @@ fn push_string_list_option(config: &TranscriptionConfig, url: &mut String, name:
 }
 
 fn push_bool_or_string_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
-    match config.model_options.get(name) {
+    match config.params.get(name) {
         Some(ModelOptionValue::Bool(value)) => url.push_str(&format!("&{name}={value}")),
         Some(ModelOptionValue::String(value)) => push_query_pair(url, name, value),
         _ => {}
@@ -147,7 +147,7 @@ fn push_bool_or_string_option(config: &TranscriptionConfig, url: &mut String, na
 }
 
 fn push_bool_or_string_list_option(config: &TranscriptionConfig, url: &mut String, name: &str) {
-    match config.model_options.get(name) {
+    match config.params.get(name) {
         Some(ModelOptionValue::Bool(value)) => url.push_str(&format!("&{name}={value}")),
         Some(ModelOptionValue::StringList(values)) => {
             for value in values {
@@ -260,7 +260,7 @@ pub(super) async fn transcribe(
         } else {
             "keywords"
         };
-        if !config.model_options.contains_key(param_name) {
+        if !config.params.contains_key(param_name) {
             for keyword in &config.keywords {
                 push_query_pair(&mut url, param_name, keyword);
             }

--- a/src/transcription/api/elevenlabs.rs
+++ b/src/transcription/api/elevenlabs.rs
@@ -191,13 +191,13 @@ pub(super) fn validate_options(
     if options.contains_key("diarization_threshold") {
         if matches!(options.get("diarize"), Some(ModelOptionValue::Bool(false))) {
             anyhow::bail!(
-                "Invalid options for '{}'. ElevenLabs diarization_threshold requires diarize = true.",
+                "Invalid params for '{}'. ElevenLabs diarization_threshold requires diarize = true.",
                 full_model_id
             );
         }
         if options.contains_key("num_speakers") {
             anyhow::bail!(
-                "Invalid options for '{}'. ElevenLabs diarization_threshold cannot be used with num_speakers.",
+                "Invalid params for '{}'. ElevenLabs diarization_threshold cannot be used with num_speakers.",
                 full_model_id
             );
         }
@@ -209,7 +209,7 @@ pub(super) fn validate_options(
     ) {
         if !matches!(options.get("diarize"), Some(ModelOptionValue::Bool(true))) {
             anyhow::bail!(
-                "Invalid options for '{}'. ElevenLabs detect_speaker_roles requires diarize = true.",
+                "Invalid params for '{}'. ElevenLabs detect_speaker_roles requires diarize = true.",
                 full_model_id
             );
         }
@@ -218,7 +218,7 @@ pub(super) fn validate_options(
             Some(ModelOptionValue::Bool(true))
         ) {
             anyhow::bail!(
-                "Invalid options for '{}'. ElevenLabs detect_speaker_roles cannot be used with use_multi_channel = true.",
+                "Invalid params for '{}'. ElevenLabs detect_speaker_roles cannot be used with use_multi_channel = true.",
                 full_model_id
             );
         }
@@ -381,7 +381,7 @@ fn add_string_or_string_list_fields(
     config: &TranscriptionConfig,
     name: &'static str,
 ) -> reqwest::multipart::Form {
-    match config.model_options.get(name) {
+    match config.params.get(name) {
         Some(ModelOptionValue::String(value)) => form = form.text(name, value.clone()),
         Some(ModelOptionValue::StringList(values)) => {
             for value in values {

--- a/src/transcription/api/groq.rs
+++ b/src/transcription/api/groq.rs
@@ -81,7 +81,7 @@ pub(super) fn validate_options(
         if let Some(ModelOptionValue::String(response_format)) = options.get("response_format") {
             if response_format != "verbose_json" {
                 anyhow::bail!(
-                    "Invalid options for '{}'. Groq timestamp_granularities requires response_format = \"verbose_json\".",
+                    "Invalid params for '{}'. Groq timestamp_granularities requires response_format = \"verbose_json\".",
                     full_model_id
                 );
             }

--- a/src/transcription/api/local.rs
+++ b/src/transcription/api/local.rs
@@ -58,7 +58,7 @@ pub(super) async fn transcribe(
 ) -> anyhow::Result<String> {
     validate_local_audio_format(audio_path)?;
     let mut local_config = config.local_config().cloned().unwrap_or_default();
-    apply_model_options(config, &mut local_config);
+    apply_params(config, &mut local_config);
 
     if let Some(text) = try_daemon_transcription(&config.model_id, audio_path, &local_config).await
     {
@@ -124,7 +124,7 @@ pub(super) async fn transcribe(
     Ok(filter_obvious_hallucination(&text).unwrap_or_default())
 }
 
-fn apply_model_options(config: &TranscriptionConfig, local_config: &mut LocalTranscriptionConfig) {
+fn apply_params(config: &TranscriptionConfig, local_config: &mut LocalTranscriptionConfig) {
     if let Some(language) = config.option_string("language") {
         local_config.language = language.to_string();
     }
@@ -220,7 +220,7 @@ pub(crate) fn load_audio_for_whisper(audio_path: &Path) -> anyhow::Result<Vec<f3
 pub(crate) fn validate_local_audio_format(audio_path: &Path) -> anyhow::Result<()> {
     let reader = hound::WavReader::open(audio_path).map_err(|err| {
         anyhow::anyhow!(
-            "Local transcription requires WAV audio: {err}. Configure [audio] with output_format = \"pcm_s16le -ar 16000\"."
+            "Whisper transcription requires WAV audio: {err}. Configure [whisper] with output_format = \"pcm_s16le -ar 16000\"."
         )
     })?;
     let spec = reader.spec();
@@ -231,7 +231,7 @@ pub(crate) fn validate_local_audio_format(audio_path: &Path) -> anyhow::Result<(
         || spec.channels != 1
     {
         anyhow::bail!(
-            "Local transcription requires WAV signed 16-bit PCM, 16 kHz, mono audio. Configure [audio] with output_format = \"pcm_s16le -ar 16000\". Current file has format {:?}, {} bits, {} Hz, {} channel(s).",
+            "Whisper transcription requires WAV signed 16-bit PCM, 16 kHz, mono audio. Configure [whisper] with output_format = \"pcm_s16le -ar 16000\". Current file has format {:?}, {} bits, {} Hz, {} channel(s).",
             spec.sample_format,
             spec.bits_per_sample,
             spec.sample_rate,

--- a/src/transcription/api/mistral.rs
+++ b/src/transcription/api/mistral.rs
@@ -74,7 +74,7 @@ pub(super) fn validate_options(
 
     if options.contains_key("language") && options.contains_key("timestamp_granularities") {
         anyhow::bail!(
-            "Invalid options for '{}'. Mistral timestamp_granularities is not compatible with language.",
+            "Invalid params for '{}'. Mistral timestamp_granularities is not compatible with language.",
             full_model_id
         );
     }

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 
 use super::model::{ModelOptionSchema, ModelSpec};
 use super::provider::TranscriptionProvider;
-use crate::config::file::{LocalTranscriptionConfig, ModelOptionValue, ProvidersConfig};
+use crate::config::file::{LocalTranscriptionConfig, ModelOptionValue};
 use indexmap::IndexMap;
 use std::ops::RangeInclusive;
 
@@ -36,10 +36,8 @@ pub struct TranscriptionConfig {
     pub api_key: String,
     /// Keywords to improve transcription accuracy
     pub keywords: Vec<String>,
-    /// Provider-specific configurations
-    pub providers: ProvidersConfig,
-    /// Validated request options for the selected model
-    pub model_options: IndexMap<String, ModelOptionValue>,
+    /// Validated request params for the selected model
+    pub params: IndexMap<String, ModelOptionValue>,
 }
 
 impl TranscriptionConfig {
@@ -50,8 +48,7 @@ impl TranscriptionConfig {
         endpoint: &'static str,
         api_key: String,
         keywords: Vec<String>,
-        providers: ProvidersConfig,
-        model_options: IndexMap<String, ModelOptionValue>,
+        params: IndexMap<String, ModelOptionValue>,
     ) -> Self {
         Self {
             provider,
@@ -59,8 +56,7 @@ impl TranscriptionConfig {
             endpoint,
             api_key,
             keywords,
-            providers,
-            model_options,
+            params,
         }
     }
 
@@ -68,45 +64,43 @@ impl TranscriptionConfig {
     pub fn new_local(
         model_id: String,
         keywords: Vec<String>,
-        providers: ProvidersConfig,
-        model_options: IndexMap<String, ModelOptionValue>,
+        params: IndexMap<String, ModelOptionValue>,
     ) -> Self {
         Self {
-            provider: TranscriptionProvider::Local,
+            provider: TranscriptionProvider::Whisper,
             model_id,
             endpoint: "",
             api_key: String::new(),
             keywords,
-            providers,
-            model_options,
+            params,
         }
     }
 
-    /// Returns the local-specific config only for local transcription requests.
+    /// Returns the built-in whisper defaults only for whisper transcription requests.
     pub fn local_config(&self) -> Option<&LocalTranscriptionConfig> {
-        if self.provider == TranscriptionProvider::Local {
-            Some(&self.providers.local)
+        if self.provider == TranscriptionProvider::Whisper {
+            None
         } else {
             None
         }
     }
 
     pub fn option_bool(&self, name: &str) -> Option<bool> {
-        match self.model_options.get(name) {
+        match self.params.get(name) {
             Some(ModelOptionValue::Bool(value)) => Some(*value),
             _ => None,
         }
     }
 
     pub fn option_string(&self, name: &str) -> Option<&str> {
-        match self.model_options.get(name) {
+        match self.params.get(name) {
             Some(ModelOptionValue::String(value)) => Some(value),
             _ => None,
         }
     }
 
     pub fn option_number(&self, name: &str) -> Option<f64> {
-        match self.model_options.get(name) {
+        match self.params.get(name) {
             Some(ModelOptionValue::Number(value)) => Some(*value),
             Some(ModelOptionValue::Integer(value)) => Some(*value as f64),
             _ => None,
@@ -114,14 +108,14 @@ impl TranscriptionConfig {
     }
 
     pub fn option_integer(&self, name: &str) -> Option<i64> {
-        match self.model_options.get(name) {
+        match self.params.get(name) {
             Some(ModelOptionValue::Integer(value)) => Some(*value),
             _ => None,
         }
     }
 
     pub fn option_string_list(&self, name: &str) -> Option<&[String]> {
-        match self.model_options.get(name) {
+        match self.params.get(name) {
             Some(ModelOptionValue::StringList(value)) => Some(value),
             _ => None,
         }
@@ -160,7 +154,7 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
         TranscriptionProvider::AssemblyAI => assemblyai::transcribe(config, audio_path).await,
         TranscriptionProvider::Berget => berget::transcribe(config, audio_path).await,
         TranscriptionProvider::ElevenLabs => elevenlabs::transcribe(config, audio_path).await,
-        TranscriptionProvider::Local => local::transcribe(config, audio_path).await,
+        TranscriptionProvider::Whisper => local::transcribe(config, audio_path).await,
         TranscriptionProvider::Mistral => mistral::transcribe(config, audio_path).await,
     }?;
 
@@ -177,12 +171,12 @@ pub(crate) fn option_schema(provider_id: &str, model_id: &str) -> Option<ModelOp
         "berget" => berget::option_schema(model_id),
         "elevenlabs" => elevenlabs::option_schema(model_id),
         "mistral" => mistral::option_schema(model_id),
-        "local" => local::option_schema(model_id),
+        "whisper" => local::option_schema(model_id),
         _ => None,
     }
 }
 
-pub(crate) fn validate_model_options(
+pub(crate) fn validate_params(
     provider_id: &str,
     full_model_id: &str,
     options: &IndexMap<String, ModelOptionValue>,
@@ -195,7 +189,7 @@ pub(crate) fn validate_model_options(
         "berget" => berget::validate_options(full_model_id, options),
         "elevenlabs" => elevenlabs::validate_options(full_model_id, options),
         "mistral" => mistral::validate_options(full_model_id, options),
-        "local" => local::validate_options(full_model_id, options),
+        "whisper" => local::validate_options(full_model_id, options),
         _ => Ok(()),
     }
 }
@@ -212,7 +206,7 @@ pub(super) fn validate_string_value(
 
     if !allowed.contains(&value.as_str()) {
         anyhow::bail!(
-            "Invalid value for option '{}' in '{}'. Expected one of: {}.",
+            "Invalid value for param '{}' in '{}'. Expected one of: {}.",
             option_name,
             full_model_id,
             allowed.join(", ")
@@ -235,7 +229,7 @@ pub(super) fn validate_string_list_values(
     for value in values {
         if !allowed.contains(&value.as_str()) {
             anyhow::bail!(
-                "Invalid value for option '{}' in '{}'. Expected one of: {}.",
+                "Invalid value for param '{}' in '{}'. Expected one of: {}.",
                 option_name,
                 full_model_id,
                 allowed.join(", ")
@@ -255,7 +249,7 @@ pub(super) fn validate_integer_range(
     if let Some(ModelOptionValue::Integer(value)) = options.get(option_name) {
         if !range.contains(value) {
             anyhow::bail!(
-                "Invalid value for option '{}' in '{}'. Expected {}-{}.",
+                "Invalid value for param '{}' in '{}'. Expected {}-{}.",
                 option_name,
                 full_model_id,
                 range.start(),
@@ -281,7 +275,7 @@ pub(super) fn validate_number_range(
 
     if !range.contains(&value) {
         anyhow::bail!(
-            "Invalid value for option '{}' in '{}'. Expected {}-{}.",
+            "Invalid value for param '{}' in '{}'. Expected {}-{}.",
             option_name,
             full_model_id,
             range.start(),
@@ -306,7 +300,7 @@ pub(super) fn validate_number_min(
 
     if value < min {
         anyhow::bail!(
-            "Invalid value for option '{}' in '{}'. Expected >= {}.",
+            "Invalid value for param '{}' in '{}'. Expected >= {}.",
             option_name,
             full_model_id,
             min

--- a/src/transcription/api/openai.rs
+++ b/src/transcription/api/openai.rs
@@ -165,7 +165,7 @@ pub(super) fn validate_options(
         if let Some(ModelOptionValue::String(response_format)) = options.get("response_format") {
             if response_format != "verbose_json" {
                 anyhow::bail!(
-                    "Invalid options for '{}'. OpenAI timestamp_granularities requires response_format = \"verbose_json\".",
+                    "Invalid params for '{}'. OpenAI timestamp_granularities requires response_format = \"verbose_json\".",
                     full_model_id
                 );
             }

--- a/src/transcription/context.rs
+++ b/src/transcription/context.rs
@@ -12,7 +12,7 @@ pub(crate) struct TranscriptionContext {
 pub(crate) fn build_context(
     ostt_config: &OsttConfig,
     model_override: Option<SelectedModel>,
-    model_option_overrides: &[String],
+    param_overrides: &[String],
 ) -> anyhow::Result<TranscriptionContext> {
     let selected_model = resolve_selected_model(ostt_config, model_override)?;
     let keywords = crate::keywords::load_keywords()?;
@@ -20,7 +20,7 @@ pub(crate) fn build_context(
         ostt_config,
         &selected_model,
         keywords.clone(),
-        model_option_overrides,
+        param_overrides,
     )?;
 
     Ok(TranscriptionContext {
@@ -56,51 +56,50 @@ fn config_for_selected_model(
     ostt_config: &OsttConfig,
     selected_model: &SelectedModel,
     keywords: Vec<String>,
-    model_option_overrides: &[String],
+    param_overrides: &[String],
 ) -> anyhow::Result<TranscriptionConfig> {
     let api_key = config::get_api_key(&selected_model.provider_id)?;
-    let full_model_id = format!("{}/{}", selected_model.provider_id, selected_model.model_id);
-    let mut model_options = ostt_config
-        .model_options
-        .get(&full_model_id)
-        .cloned()
+    let mut params = ostt_config
+        .provider_configs
+        .get(&selected_model.provider_id)
+        .map(|provider| provider.params.clone())
         .unwrap_or_default();
-    model_options.extend(parse_model_option_overrides(
-        selected_model,
-        model_option_overrides,
-    )?);
-    let mut options_to_validate = config::ModelOptionsConfig::new();
-    options_to_validate.insert(full_model_id, model_options.clone());
-    config::file::validate_model_options(&options_to_validate)?;
+    if let Some(model_config) = ostt_config
+        .provider_configs
+        .get(&selected_model.provider_id)
+        .and_then(|provider| provider.models.get(&selected_model.model_id))
+    {
+        params.extend(model_config.params.clone());
+    }
+    params.extend(parse_param_overrides(selected_model, param_overrides)?);
+    config::file::validate_params_for_model(
+        &selected_model.provider_id,
+        &selected_model.model_id,
+        &params,
+    )?;
 
-    super::config_for_selected_model(
-        selected_model,
-        api_key,
-        keywords,
-        ostt_config.providers.clone(),
-        model_options,
-    )
+    super::config_for_selected_model(selected_model, api_key, keywords, params)
 }
 
-fn parse_model_option_overrides(
+fn parse_param_overrides(
     selected_model: &SelectedModel,
     overrides: &[String],
 ) -> anyhow::Result<IndexMap<String, config::ModelOptionValue>> {
     let schema = super::api::option_schema(&selected_model.provider_id, &selected_model.model_id)
-        .ok_or_else(|| anyhow::anyhow!("No model options are supported for this model"))?;
+        .ok_or_else(|| anyhow::anyhow!("No params are supported for this model"))?;
     let full_model_id = format!("{}/{}", selected_model.provider_id, selected_model.model_id);
     let mut parsed = IndexMap::new();
 
     for override_value in overrides {
-        let (name, raw_value) = override_value
-            .split_once('=')
-            .ok_or_else(|| anyhow::anyhow!("Invalid --mo '{}'. Use key=value.", override_value))?;
+        let (name, raw_value) = override_value.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!("Invalid --param '{}'. Use key=value.", override_value)
+        })?;
         if parsed.contains_key(name) {
-            anyhow::bail!("Duplicate --mo option '{}'.", name);
+            anyhow::bail!("Duplicate --param '{}'.", name);
         }
         let Some(spec) = schema.option(name) else {
             anyhow::bail!(
-                "Invalid option '{}' for '{}'. Supported options: {}.",
+                "Invalid param '{}' for '{}'. Supported params: {}.",
                 name,
                 full_model_id,
                 schema.option_names().join(", ")
@@ -187,68 +186,68 @@ mod tests {
     }
 
     #[test]
-    fn model_option_overrides_reject_duplicate_keys() {
+    fn param_overrides_reject_duplicate_keys() {
         let model = selected_model("deepgram", "nova-3");
-        let err = parse_model_option_overrides(
+        let err = parse_param_overrides(
             &model,
             &["language=sv".to_string(), "language=en".to_string()],
         )
         .unwrap_err()
         .to_string();
 
-        assert!(err.contains("Duplicate --mo option 'language'"));
+        assert!(err.contains("Duplicate --param 'language'"));
     }
 
     #[test]
-    fn model_option_overrides_reject_missing_equals() {
+    fn param_overrides_reject_missing_equals() {
         let model = selected_model("deepgram", "nova-3");
-        let err = parse_model_option_overrides(&model, &["diarize".to_string()])
+        let err = parse_param_overrides(&model, &["diarize".to_string()])
             .unwrap_err()
             .to_string();
 
-        assert!(err.contains("Invalid --mo 'diarize'"));
+        assert!(err.contains("Invalid --param 'diarize'"));
         assert!(err.contains("key=value"));
     }
 
     #[test]
-    fn model_option_overrides_reject_unknown_option() {
+    fn param_overrides_reject_unknown_param() {
         let model = selected_model("openai", "gpt-4o-transcribe");
-        let err = parse_model_option_overrides(&model, &["smart_format=true".to_string()])
+        let err = parse_param_overrides(&model, &["smart_format=true".to_string()])
             .unwrap_err()
             .to_string();
 
-        assert!(err.contains("Invalid option 'smart_format'"));
-        assert!(err.contains("Supported options"));
+        assert!(err.contains("Invalid param 'smart_format'"));
+        assert!(err.contains("Supported params"));
     }
 
     #[test]
-    fn model_option_overrides_reject_invalid_bool_and_number_values() {
+    fn param_overrides_reject_invalid_bool_and_number_values() {
         let bool_model = selected_model("deepgram", "nova-3");
-        let err = parse_model_option_overrides(&bool_model, &["diarize=yes".to_string()])
+        let err = parse_param_overrides(&bool_model, &["diarize=yes".to_string()])
             .unwrap_err()
             .to_string();
         assert!(err.contains("provided string was not `true` or `false`"));
 
         let number_model = selected_model("openai", "gpt-4o-transcribe");
-        let err = parse_model_option_overrides(&number_model, &["temperature=hot".to_string()])
+        let err = parse_param_overrides(&number_model, &["temperature=hot".to_string()])
             .unwrap_err()
             .to_string();
         assert!(err.contains("invalid float literal"));
     }
 
     #[test]
-    fn model_option_overrides_reject_empty_string_for_string_typed_option() {
+    fn param_overrides_reject_empty_string_for_string_typed_option() {
         let model = selected_model("openai", "gpt-4o-transcribe");
-        let err = parse_model_option_overrides(&model, &["prompt=".to_string()])
+        let err = parse_param_overrides(&model, &["prompt=".to_string()])
             .unwrap_err()
             .to_string();
         assert!(err.contains("must not be empty"));
     }
 
     #[test]
-    fn model_option_overrides_parse_local_whisper_options() {
-        let model = selected_model("local", "turbo");
-        let options = parse_model_option_overrides(
+    fn param_overrides_parse_whisper_params() {
+        let model = selected_model("whisper", "turbo");
+        let options = parse_param_overrides(
             &model,
             &[
                 "language=sv".to_string(),
@@ -273,10 +272,10 @@ mod tests {
     }
 
     #[test]
-    fn model_option_overrides_parse_bool_or_string_list_bool() {
+    fn param_overrides_parse_bool_or_string_list_bool() {
         let model = selected_model("deepgram", "nova-3");
         let options =
-            parse_model_option_overrides(&model, &["detect_language=false".to_string()]).unwrap();
+            parse_param_overrides(&model, &["detect_language=false".to_string()]).unwrap();
 
         assert_eq!(
             options.get("detect_language"),
@@ -285,10 +284,9 @@ mod tests {
     }
 
     #[test]
-    fn model_option_overrides_parse_string_lists() {
+    fn param_overrides_parse_string_lists() {
         let model = selected_model("deepgram", "nova-3");
-        let options =
-            parse_model_option_overrides(&model, &["keyterm=OSTT,whisper".to_string()]).unwrap();
+        let options = parse_param_overrides(&model, &["keyterm=OSTT,whisper".to_string()]).unwrap();
 
         assert_eq!(
             options.get("keyterm"),
@@ -300,10 +298,10 @@ mod tests {
     }
 
     #[test]
-    fn model_option_overrides_parse_bool_or_string_lists() {
+    fn param_overrides_parse_bool_or_string_lists() {
         let model = selected_model("deepgram", "nova-3");
         let options =
-            parse_model_option_overrides(&model, &["detect_language=sv,en".to_string()]).unwrap();
+            parse_param_overrides(&model, &["detect_language=sv,en".to_string()]).unwrap();
 
         assert_eq!(
             options.get("detect_language"),

--- a/src/transcription/local_models.rs
+++ b/src/transcription/local_models.rs
@@ -101,9 +101,11 @@ pub fn model_files_dir() -> PathBuf {
 /// Error type for local model-related failures.
 #[derive(Debug, thiserror::Error)]
 pub enum ModelError {
-    #[error("Local model 'local/{0}' was not found in the local model registry or custom models.")]
+    #[error(
+        "Local model 'whisper/{0}' was not found in the local model registry or custom models."
+    )]
     NotFound(String),
-    #[error("Local model 'local/{0}' is not downloaded. Run `ostt model` to download it.")]
+    #[error("Local model 'whisper/{0}' is not downloaded. Run `ostt model` to download it.")]
     NotDownloaded(String),
     #[error("Model file not found at {0}")]
     FileNotFound(PathBuf),
@@ -231,7 +233,7 @@ pub fn is_safe_model_id(id: &str) -> bool {
 }
 
 pub fn full_model_id(id: &str) -> String {
-    format!("local/{id}")
+    format!("whisper/{id}")
 }
 
 pub fn installed_models(
@@ -253,7 +255,7 @@ pub fn installed_models(
                 modified_at: metadata.modified().ok(),
                 is_active: selected_model
                     .map(|selected| {
-                        selected.provider_id == "local" && selected.model_id == entry.id
+                        selected.provider_id == "whisper" && selected.model_id == entry.id
                     })
                     .unwrap_or(false),
             })
@@ -700,7 +702,7 @@ pub fn activate_model(model_id: &str) -> anyhow::Result<()> {
     if !path.exists() {
         return Err(ModelError::NotDownloaded(model_id.to_string()).into());
     }
-    config::save_selected_model("local", model_id)
+    config::save_selected_model("whisper", model_id)
 }
 
 pub fn deactivate_model() -> anyhow::Result<()> {
@@ -720,7 +722,7 @@ pub fn delete_model(model_id: &str) -> anyhow::Result<()> {
     }
 
     if config::get_selected_model_entry()?
-        .is_some_and(|selected| selected.provider_id == "local" && selected.model_id == model_id)
+        .is_some_and(|selected| selected.provider_id == "whisper" && selected.model_id == model_id)
     {
         config::clear_selected_model()?;
     }
@@ -1032,7 +1034,7 @@ mod tests {
             fs::create_dir_all(model_files_dir()).expect("create files dir");
             fs::write(model_files_dir().join("turbo.bin"), [1]).expect("write model");
             let selected_model = SelectedModel {
-                provider_id: "local".to_string(),
+                provider_id: "whisper".to_string(),
                 model_id: "turbo".to_string(),
             };
 
@@ -1063,7 +1065,7 @@ mod tests {
                 .expect("load selected model")
                 .expect("selected model");
 
-            assert_eq!(selected.provider_id, "local");
+            assert_eq!(selected.provider_id, "whisper");
             assert_eq!(selected.model_id, "custom");
         });
     }
@@ -1089,7 +1091,7 @@ mod tests {
     #[test]
     fn deactivate_model_clears_selected_model() {
         with_isolated_data_dir(|_| {
-            config::save_selected_model("local", "custom").expect("save selected model");
+            config::save_selected_model("whisper", "custom").expect("save selected model");
 
             deactivate_model().expect("deactivate model");
 
@@ -1110,7 +1112,7 @@ mod tests {
             fs::create_dir_all(model_files_dir()).expect("create files dir");
             let file_path = model_files_dir().join("custom.bin");
             fs::write(&file_path, [1]).expect("write custom model");
-            config::save_selected_model("local", "custom").expect("save selected model");
+            config::save_selected_model("whisper", "custom").expect("save selected model");
 
             delete_model("custom").expect("delete model");
 
@@ -1396,7 +1398,7 @@ mod tests {
         env::set_var("HOME", &dir);
         env::set_var("XDG_CONFIG_HOME", dir.join(".config"));
         env::set_var("XDG_DATA_HOME", dir.join(".local").join("share"));
-        config::save_selected_model("local", "active").expect("save selected model");
+        config::save_selected_model("whisper", "active").expect("save selected model");
         let dest_path = model_files_dir().join("turbo.bin");
 
         download_model(&first_url, &dest_path, None)

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -29,8 +29,7 @@ pub fn config_for_selected_model(
     selected_model: &crate::config::SelectedModel,
     api_key: Option<String>,
     keywords: Vec<String>,
-    providers: crate::config::file::ProvidersConfig,
-    model_options: indexmap::IndexMap<String, crate::config::ModelOptionValue>,
+    params: indexmap::IndexMap<String, crate::config::ModelOptionValue>,
 ) -> anyhow::Result<TranscriptionConfig> {
     let provider =
         TranscriptionProvider::from_id(&selected_model.provider_id).ok_or_else(|| {
@@ -41,12 +40,11 @@ pub fn config_for_selected_model(
             )
         })?;
 
-    if provider == TranscriptionProvider::Local {
+    if provider == TranscriptionProvider::Whisper {
         return Ok(TranscriptionConfig::new_local(
             selected_model.model_id.clone(),
             keywords,
-            providers,
-            model_options,
+            params,
         ));
     }
 
@@ -68,8 +66,7 @@ pub fn config_for_selected_model(
         model.endpoint,
         api_key,
         keywords,
-        providers,
-        model_options,
+        params,
     ))
 }
 

--- a/src/transcription/provider.rs
+++ b/src/transcription/provider.rs
@@ -15,7 +15,7 @@ pub enum TranscriptionProvider {
     AssemblyAI,
     Berget,
     ElevenLabs,
-    Local,
+    Whisper,
     Mistral,
 }
 
@@ -29,7 +29,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::AssemblyAI => "assemblyai",
             TranscriptionProvider::Berget => "berget",
             TranscriptionProvider::ElevenLabs => "elevenlabs",
-            TranscriptionProvider::Local => "local",
+            TranscriptionProvider::Whisper => "whisper",
             TranscriptionProvider::Mistral => "mistral",
         }
     }
@@ -43,7 +43,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::AssemblyAI => "AssemblyAI",
             TranscriptionProvider::Berget => "Berget",
             TranscriptionProvider::ElevenLabs => "ElevenLabs",
-            TranscriptionProvider::Local => "Local (whisper.cpp)",
+            TranscriptionProvider::Whisper => "Whisper (local whisper.cpp)",
             TranscriptionProvider::Mistral => "Mistral",
         }
     }
@@ -57,7 +57,7 @@ impl TranscriptionProvider {
             "assemblyai" => Some(TranscriptionProvider::AssemblyAI),
             "berget" => Some(TranscriptionProvider::Berget),
             "elevenlabs" => Some(TranscriptionProvider::ElevenLabs),
-            "local" => Some(TranscriptionProvider::Local),
+            "whisper" => Some(TranscriptionProvider::Whisper),
             "mistral" => Some(TranscriptionProvider::Mistral),
             _ => None,
         }
@@ -72,7 +72,7 @@ impl TranscriptionProvider {
             TranscriptionProvider::AssemblyAI,
             TranscriptionProvider::Berget,
             TranscriptionProvider::ElevenLabs,
-            TranscriptionProvider::Local,
+            TranscriptionProvider::Whisper,
             TranscriptionProvider::Mistral,
         ]
     }


### PR DESCRIPTION
## Summary
- Replace public model options terminology with transcription params: --param and ostt model params.
- Move persistent params to top-level provider tables: [provider.params] and [provider."model".params].
- Rename the built-in local provider ID from local to whisper.
- Add provider_id support to local model registry entries and accept MODEL_ID or PROVIDER/MODEL in ostt model local download/remove.
- Save local model selections from the registry entry provider_id in both the TUI and command-line model selection paths.
- Fail loudly for deprecated [providers], [model_options], [audio].sample_rate, [[process.actions]], and provider = "local" config shapes.
- Resolve Whisper recording format from provider/model config instead of mutating global audio config.

## Verification
- cargo check
- cargo test --lib
- git diff --check

## Related
- Registry update: https://github.com/kristoferlund/ostt-models/pull/1
- Docs update: https://github.com/kristoferlund/ostt-web/pull/3