### PR TITLE
Add external command and HTTP transcription providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added external `command/<profile>` transcription providers that run configured shell commands with `{audio_path}` and read transcript text from stdout.
+- Added external `http/<profile>` transcription providers for OpenAI-compatible `/v1/audio/transcriptions` endpoints with validated request params.
+
+### Changed
+
+- `ostt model` now uses a unified picker with custom, cloud, and local models in one list.
+- `ostt model list` and `ostt model select` now support configured `command/*` and `http/*` profiles.
+
 ## 0.0.18 - 2026-06-02
 
 ### Changed

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -176,7 +176,7 @@ fn provider_by_id(
 fn cloud_providers() -> Vec<transcription::TranscriptionProvider> {
     transcription::TranscriptionProvider::all()
         .iter()
-        .filter(|provider| **provider != transcription::TranscriptionProvider::Whisper)
+        .filter(|provider| provider.requires_auth())
         .cloned()
         .collect()
 }

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -43,6 +43,37 @@ pub async fn handle_model_list(
                 }),
             });
         }
+
+        if provider
+            .as_deref()
+            .is_none_or(|id| matches!(id, "command" | "http"))
+        {
+            let config = crate::config::OsttConfig::load()
+                .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+            for provider_id in ["command", "http"] {
+                if provider.as_deref().is_some_and(|id| id != provider_id) {
+                    continue;
+                }
+                if let Some(provider_config) = config.provider_configs.get(provider_id) {
+                    for (profile_id, profile) in &provider_config.models {
+                        rows.push(ModelListRow {
+                            provider: provider_id.to_string(),
+                            model: profile_id.clone(),
+                            name: profile
+                                .settings
+                                .display_name
+                                .clone()
+                                .unwrap_or_else(|| profile_id.clone()),
+                            installed: None,
+                            active: selected.as_ref().is_some_and(|selected| {
+                                selected.provider_id == provider_id
+                                    && selected.model_id == *profile_id
+                            }),
+                        });
+                    }
+                }
+            }
+        }
     }
 
     if provider.as_deref().is_none_or(|id| id == "whisper") {
@@ -161,6 +192,29 @@ pub async fn handle_model_select(model: String) -> anyhow::Result<()> {
         println!(
             "Selected model: {}/{}",
             activated.provider_id, activated.model_id
+        );
+        return Ok(());
+    }
+
+    if matches!(selected.provider_id.as_str(), "command" | "http") {
+        let config =
+            crate::config::OsttConfig::load().map_err(|err| anyhow::anyhow!(err.to_string()))?;
+        if config
+            .provider_configs
+            .get(&selected.provider_id)
+            .and_then(|provider| provider.models.get(&selected.model_id))
+            .is_none()
+        {
+            anyhow::bail!(
+                "Unknown external profile: {}/{}",
+                selected.provider_id,
+                selected.model_id
+            );
+        }
+        crate::config::save_selected_model(&selected.provider_id, &selected.model_id)?;
+        println!(
+            "Selected model: {}/{}",
+            selected.provider_id, selected.model_id
         );
         return Ok(());
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -157,9 +157,7 @@ pub struct ProviderSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub api_key_env: Option<String>,
+    pub api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }
@@ -818,13 +816,7 @@ fn parse_params_table(
 fn is_provider_setting_key(key: &str) -> bool {
     matches!(
         key,
-        "output_format"
-            | "timeout_secs"
-            | "command"
-            | "endpoint"
-            | "model"
-            | "api_key_env"
-            | "display_name"
+        "output_format" | "timeout_secs" | "command" | "endpoint" | "api_key" | "display_name"
     )
 }
 
@@ -838,8 +830,7 @@ fn set_provider_setting(
         "timeout_secs" => settings.timeout_secs = Some(value.try_into()?),
         "command" => settings.command = Some(value.try_into()?),
         "endpoint" => settings.endpoint = Some(value.try_into()?),
-        "model" => settings.model = Some(value.try_into()?),
-        "api_key_env" => settings.api_key_env = Some(value.try_into()?),
+        "api_key" => settings.api_key = Some(value.try_into()?),
         "display_name" => settings.display_name = Some(value.try_into()?),
         _ => unreachable!("unknown provider setting was pre-filtered"),
     }
@@ -914,14 +905,8 @@ fn provider_settings_to_table(settings: &ProviderSettings) -> anyhow::Result<tom
     if let Some(value) = &settings.endpoint {
         table.insert("endpoint".to_string(), toml::Value::String(value.clone()));
     }
-    if let Some(value) = &settings.model {
-        table.insert("model".to_string(), toml::Value::String(value.clone()));
-    }
-    if let Some(value) = &settings.api_key_env {
-        table.insert(
-            "api_key_env".to_string(),
-            toml::Value::String(value.clone()),
-        );
+    if let Some(value) = &settings.api_key {
+        table.insert("api_key".to_string(), toml::Value::String(value.clone()));
     }
     if let Some(value) = &settings.display_name {
         table.insert(
@@ -934,17 +919,81 @@ fn provider_settings_to_table(settings: &ProviderSettings) -> anyhow::Result<tom
 
 pub fn validate_config(config: &OsttConfig) -> anyhow::Result<()> {
     for (provider_id, provider_config) in &config.provider_configs {
-        if crate::transcription::TranscriptionProvider::from_id(provider_id).is_none() {
+        let Some(provider) = crate::transcription::TranscriptionProvider::from_id(provider_id)
+        else {
             anyhow::bail!("Unknown provider config '{}'.", provider_id);
-        }
+        };
 
-        for model_id in provider_config.models.keys() {
+        for (model_id, model_config) in &provider_config.models {
             validate_model_id(provider_id, model_id)?;
+            validate_external_profile(provider.id(), model_id, model_config)?;
         }
     }
 
     if config.transcription.provider.as_deref() == Some("local") {
         anyhow::bail!("Provider 'local' is no longer supported. Use provider = \"whisper\".");
+    }
+
+    Ok(())
+}
+
+fn validate_external_profile(
+    provider_id: &str,
+    profile_id: &str,
+    config: &ProviderModelConfig,
+) -> anyhow::Result<()> {
+    match provider_id {
+        "command" => {
+            let command = config.settings.command.as_deref().unwrap_or_default();
+            if command.trim().is_empty() {
+                anyhow::bail!(
+                    "Command profile '{}': missing required 'command'.",
+                    profile_id
+                );
+            }
+            validate_command_template(profile_id, command)?;
+        }
+        "http" => {
+            let endpoint = config.settings.endpoint.as_deref().unwrap_or_default();
+            if endpoint.trim().is_empty() {
+                anyhow::bail!(
+                    "HTTP profile '{}': missing required 'endpoint'.",
+                    profile_id
+                );
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn validate_command_template(profile_id: &str, command: &str) -> anyhow::Result<()> {
+    let mut rest = command;
+    while let Some(start) = rest.find('{') {
+        let after_start = &rest[start + 1..];
+        let Some(end) = after_start.find('}') else {
+            anyhow::bail!(
+                "Command profile '{}': unclosed template placeholder.",
+                profile_id
+            );
+        };
+        let placeholder = &after_start[..end];
+        if placeholder != "audio_path" {
+            anyhow::bail!(
+                "Command profile '{}': unknown template placeholder '{{{}}}'. Supported placeholders: {{audio_path}}.",
+                profile_id,
+                placeholder
+            );
+        }
+        rest = &after_start[end + 1..];
+    }
+
+    if rest.contains('}') {
+        anyhow::bail!(
+            "Command profile '{}': unmatched '}}' in command.",
+            profile_id
+        );
     }
 
     Ok(())
@@ -999,6 +1048,16 @@ pub fn save_config(config: &OsttConfig) -> anyhow::Result<()> {
 }
 
 pub fn validate_model_id(provider_id: &str, model_id: &str) -> anyhow::Result<()> {
+    if matches!(provider_id, "command" | "http") {
+        if !crate::transcription::local_models::is_safe_model_id(model_id) {
+            anyhow::bail!(
+                "External profile id '{}' must contain only lowercase letters, digits, '.', '_' or '-'.",
+                model_id
+            );
+        }
+        return Ok(());
+    }
+
     if provider_id != "whisper" && model::find_model(provider_id, model_id).is_none() {
         anyhow::bail!(
             "Unknown model '{}' for provider '{}'. Please run 'ostt model' to select a supported model.",
@@ -1024,12 +1083,15 @@ pub fn validate_params_for_model(
 ) -> anyhow::Result<()> {
     validate_model_id(provider_id, model_id)?;
     let full_model_id = format!("{provider_id}/{model_id}");
-    let schema = api::option_schema(provider_id, model_id).ok_or_else(|| {
-        anyhow::anyhow!(
+    let Some(schema) = api::option_schema(provider_id, model_id) else {
+        if params.is_empty() {
+            return Ok(());
+        }
+        anyhow::bail!(
             "Invalid params for '{}'. No params are supported for this model.",
             full_model_id
-        )
-    })?;
+        );
+    };
 
     for (option_name, value) in params {
         let Some(spec) = schema.option(option_name) else {
@@ -1506,6 +1568,84 @@ mod tests {
 
         let config = parse_ostt_config(toml_str).unwrap();
         validate_ostt_config(&config).unwrap();
+    }
+
+    #[test]
+    fn external_command_profile_requires_known_audio_path_placeholder() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [command.parakeet-fast]
+            command = "parakeet --input {file}"
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+
+        assert!(err.contains("unknown template placeholder"), "{err}");
+        assert!(err.contains("{audio_path}"), "{err}");
+    }
+
+    #[test]
+    fn external_profiles_parse_backend_settings_and_params() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [command.parakeet-fast]
+            display_name = "Parakeet"
+            command = "parakeet {audio_path}"
+            output_format = "pcm_s16le -ar 16000"
+            timeout_secs = 120
+
+            [http.speaches]
+            display_name = "Speaches"
+            endpoint = "http://localhost:8000/v1/audio/transcriptions"
+            api_key = ""
+            output_format = "mp3 -ab 16k -ar 12000"
+            timeout_secs = 60
+
+            [http.speaches.params]
+            model = "Systran/faster-whisper-large-v3"
+            response_format = "json"
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+        validate_ostt_config(&config).unwrap();
+
+        let command = &config.provider_configs["command"].models["parakeet-fast"];
+        assert_eq!(
+            command.settings.command.as_deref(),
+            Some("parakeet {audio_path}")
+        );
+        assert_eq!(command.settings.timeout_secs, Some(120));
+
+        let http = &config.provider_configs["http"].models["speaches"];
+        assert_eq!(http.settings.api_key.as_deref(), Some(""));
+        assert_eq!(
+            http.params["model"],
+            ModelOptionValue::String("Systran/faster-whisper-large-v3".to_string())
+        );
+    }
+
+    #[test]
+    fn http_profile_rejects_unsupported_response_format() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [http.speaches]
+            endpoint = "http://localhost:8000/v1/audio/transcriptions"
+
+            [http.speaches.params]
+            model = "large-v3"
+            response_format = "text"
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+
+        assert!(err.contains("response_format"), "{err}");
+        assert!(err.contains("json"), "{err}");
     }
 
     #[test]

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -40,6 +40,8 @@ pub fn parse_provider_model(value: &str) -> anyhow::Result<SelectedModel> {
     }
 
     if provider != Some(TranscriptionProvider::Whisper)
+        && provider != Some(TranscriptionProvider::Command)
+        && provider != Some(TranscriptionProvider::Http)
         && find_model(provider_id, model_id).is_none()
     {
         anyhow::bail!(

--- a/src/model/local_model_view/custom_model_details_dialog.rs
+++ b/src/model/local_model_view/custom_model_details_dialog.rs
@@ -29,7 +29,7 @@ impl CustomModelDetailsDialog {
             Line::from(""),
             wizard_button("Download", selected_action),
         ];
-        render_dialog_content(frame, "Download Custom Model 2/3", lines, 70, 13);
+        render_dialog_content(frame, "Download Custom Whisper Model 2/3", lines, 70, 13);
         render_dialog_input(frame, id_input, 13, 5);
         render_dialog_input(frame, name_input, 13, 8);
         match focus {

--- a/src/model/local_model_view/custom_model_url_input_dialog.rs
+++ b/src/model/local_model_view/custom_model_url_input_dialog.rs
@@ -21,7 +21,7 @@ impl CustomModelUrlInputDialog {
             Line::from(""),
             wizard_button("Next", selected_action),
         ];
-        render_dialog_content(frame, "Download Custom Model 1/3", lines, 70, 10);
+        render_dialog_content(frame, "Download Custom Whisper Model 1/3", lines, 70, 10);
         render_dialog_input(frame, input, 10, 5);
         set_custom_input_cursor(frame, input, 10, 5);
     }

--- a/src/model/local_model_view/local_model_download_progress_dialog.rs
+++ b/src/model/local_model_view/local_model_download_progress_dialog.rs
@@ -22,7 +22,7 @@ impl LocalModelDownloadProgressDialog {
         render_dialog_content(
             frame,
             if state.is_custom {
-                "Download Custom Model 3/3"
+                "Download Custom Whisper Model 3/3"
             } else {
                 state.status.as_str()
             },

--- a/src/model/local_model_view/local_model_list_view.rs
+++ b/src/model/local_model_view/local_model_list_view.rs
@@ -1,9 +1,10 @@
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState};
 use ratatui::Frame;
 
-use crate::ui::{render_app_layout, render_footer, render_title};
+use crate::ui::{render_app_layout, render_footer};
 
 use super::local_model_view_helpers::format_bytes;
 use super::types::{LocalModelEntry, LocalModelsTui};
@@ -13,11 +14,20 @@ pub(super) struct LocalModelListView;
 impl LocalModelListView {
     pub(super) fn render(frame: &mut Frame<'_>, tui: &LocalModelsTui) {
         let layout = render_app_layout(frame, frame.area());
-        render_title(frame, layout.title, "Local models");
+        let body = Rect {
+            x: layout.title.x,
+            y: layout.title.y,
+            width: layout.title.width,
+            height: layout.title.height.saturating_add(layout.body.height),
+        };
 
-        let selected_id = tui.selected_entry().map(|e| e.id.as_str());
+        let selected_id = tui.selected_entry().map(model_key);
         let mut items = Vec::new();
-        push_grouped_model_items(&mut items, tui.entries.iter().collect(), selected_id);
+        push_grouped_model_items(
+            &mut items,
+            tui.entries.iter().collect(),
+            selected_id.as_deref(),
+        );
 
         let selected_display_index = display_index_for_selected_model(tui);
         let mut state = ListState::default().with_selected(selected_display_index);
@@ -25,7 +35,7 @@ impl LocalModelListView {
         // so pill background colours are preserved on the selected row.
         frame.render_stateful_widget(
             List::new(items).highlight_style(Style::default()),
-            layout.body,
+            body,
             &mut state,
         );
 
@@ -39,8 +49,8 @@ impl LocalModelListView {
 
 fn section_header(label: impl Into<String>) -> ListItem<'static> {
     ListItem::new(Line::from(Span::styled(
-        label.into(),
-        Style::default().add_modifier(Modifier::BOLD),
+        format!(" {} ", label.into()),
+        Style::default().fg(Color::Black).bg(Color::Cyan),
     )))
 }
 
@@ -51,22 +61,22 @@ fn push_grouped_model_items(
 ) {
     let mut current_group: Option<&str> = None;
     for entry in entries {
-        let group = entry.group_id.as_deref().unwrap_or("Custom");
+        let group = entry.group_id.as_deref().unwrap_or("Custom models");
         if current_group != Some(group) {
             if current_group.is_some() {
                 items.push(ListItem::new(Line::from("")));
             }
             items.push(section_header(group.to_string()));
+            items.push(ListItem::new(Line::from("")));
             current_group = Some(group);
         }
-        let is_selected = selected_id == Some(entry.id.as_str());
+        let is_selected = selected_id.as_deref() == Some(model_key(entry).as_str());
         items.push(local_model_list_item(entry, is_selected));
     }
 }
 
 fn local_model_list_item(entry: &LocalModelEntry, is_selected: bool) -> ListItem<'static> {
     let active_marker = if entry.is_active { "◉" } else { "○" };
-    let size = format_bytes(u64::from(entry.size_mb) * 1024 * 1024);
     let description = entry.description.trim();
 
     let row_bg = if is_selected {
@@ -78,7 +88,7 @@ fn local_model_list_item(entry: &LocalModelEntry, is_selected: bool) -> ListItem
 
     let mut spans = vec![Span::styled(format!("{active_marker} "), row_style)];
 
-    if entry.is_downloaded {
+    if entry.is_downloaded && entry.provider_id == "whisper" {
         let (pill_fg, pill_bg) = if is_selected {
             (Color::Black, Color::LightGreen)
         } else {
@@ -104,17 +114,36 @@ fn local_model_list_item(entry: &LocalModelEntry, is_selected: bool) -> ListItem
         spans.push(Span::styled(" ", row_style));
     }
 
-    spans.push(Span::styled(
-        format!("{}, {}, {}", entry.name, size, description),
-        row_style,
-    ));
+    let details = if entry.provider_id == "whisper" {
+        let size = format_bytes(u64::from(entry.size_mb) * 1024 * 1024);
+        if description.is_empty() {
+            format!(
+                "{}  {}/{}  {}",
+                entry.name, entry.provider_id, entry.id, size
+            )
+        } else {
+            format!(
+                "{}  {}/{}  {}  {}",
+                entry.name, entry.provider_id, entry.id, size, description
+            )
+        }
+    } else if description.is_empty() {
+        format!("{}  {}/{}", entry.name, entry.provider_id, entry.id)
+    } else {
+        format!(
+            "{}  {}/{}  {}",
+            entry.name, entry.provider_id, entry.id, description
+        )
+    };
+
+    spans.push(Span::styled(details, row_style));
 
     ListItem::new(Line::from(spans))
 }
 
 fn display_index_for_selected_model(tui: &LocalModelsTui) -> Option<usize> {
-    let selected_entry_id = tui.selected_entry().map(|entry| entry.id.as_str())?;
-    grouped_display_index(tui.entries.iter().collect(), selected_entry_id, 0)
+    let selected_entry_id = tui.selected_entry().map(model_key)?;
+    grouped_display_index(tui.entries.iter().collect(), &selected_entry_id, 0)
 }
 
 pub(super) fn grouped_display_index(
@@ -125,18 +154,22 @@ pub(super) fn grouped_display_index(
     let mut index = start_index;
     let mut current_group: Option<&str> = None;
     for entry in entries {
-        let group = entry.group_id.as_deref().unwrap_or("Custom");
+        let group = entry.group_id.as_deref().unwrap_or("Custom models");
         if current_group != Some(group) {
             if current_group.is_some() {
                 index += 1;
             }
-            index += 1;
+            index += 2;
             current_group = Some(group);
         }
-        if entry.id == selected_entry_id {
+        if model_key(entry) == selected_entry_id {
             return Some(index);
         }
         index += 1;
     }
     None
+}
+
+fn model_key(entry: &LocalModelEntry) -> String {
+    format!("{}/{}", entry.provider_id, entry.id)
 }

--- a/src/model/local_model_view/mod.rs
+++ b/src/model/local_model_view/mod.rs
@@ -27,6 +27,7 @@ use crate::transcription::local_models::{
     resolve_custom_model, validate_custom_model_registration, validate_downloaded_model,
     DownloadHandle, LocalModelState, RegistryEntry,
 };
+use crate::transcription::{self, TranscriptionProvider};
 use crate::ui::{render_error_dialog, render_toast, DialogAction, Toast};
 
 use custom_model_details_dialog::CustomModelDetailsDialog;
@@ -43,6 +44,9 @@ use types::{
 
 pub(crate) async fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> anyhow::Result<()> {
     let local_state = load_state();
+    let ostt_config =
+        config::OsttConfig::load().map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    let authorized_provider_ids = config::get_authorized_providers()?;
     let registry = match fetch_registry().await {
         Ok(registry) => registry,
         Err(error) => {
@@ -57,7 +61,9 @@ pub(crate) async fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> an
         .await
         .map(|d| d.model_id);
 
-    let entries = build_local_model_entries(
+    let entries = build_model_entries(
+        &ostt_config,
+        &authorized_provider_ids,
         &local_state,
         &registry,
         selected_model.as_ref(),
@@ -177,51 +183,193 @@ fn render_local_models(frame: &mut Frame<'_>, tui: &LocalModelsTui) {
     }
 }
 
-fn build_local_model_entries(
+pub(crate) fn build_model_entries(
+    config: &config::OsttConfig,
+    authorized_provider_ids: &[String],
     local_state: &LocalModelState,
     registry: &[RegistryEntry],
     selected_model: Option<&SelectedModel>,
     daemon_model_id: Option<&str>,
 ) -> Vec<LocalModelEntry> {
-    // Custom entries are appended to the remote registry and marked as non-registry models.
-    registry
-        .iter()
-        .chain(local_state.custom_models.iter())
-        .map(|entry| {
-            let is_downloaded = model_destination(entry).exists();
-            let is_active = selected_model
-                .map(|selected| {
-                    selected.provider_id == entry.provider_id && selected.model_id == entry.id
-                })
-                .unwrap_or(false);
-            let is_daemon_loaded = daemon_model_id == Some(entry.id.as_str());
+    let mut entries = Vec::new();
+    entries.extend(build_custom_model_entries(
+        config,
+        local_state,
+        selected_model,
+        daemon_model_id,
+    ));
+    entries.extend(build_cloud_model_entries(
+        authorized_provider_ids,
+        selected_model,
+    ));
+    entries.extend(build_local_model_entries(
+        local_state,
+        registry,
+        selected_model,
+        daemon_model_id,
+    ));
+    entries
+}
 
-            LocalModelEntry {
-                id: entry.id.clone(),
-                provider_id: entry.provider_id.clone(),
-                name: entry.name.clone(),
-                description: entry.description.clone(),
-                size_mb: entry.size_mb,
-                is_downloaded,
-                is_active,
-                is_daemon_loaded,
-                is_available_in_registry: registry
-                    .iter()
-                    .any(|registry_entry| registry_entry.id == entry.id),
-                languages: entry.languages.clone(),
-                url: entry.url.clone(),
-                recommended_hardware: entry.recommended_hardware.clone(),
-                category: entry.category.clone(),
-                sha256: entry.sha256.clone(),
-                group_id: entry.group_id.clone(),
-            }
+fn build_custom_model_entries(
+    config: &config::OsttConfig,
+    local_state: &LocalModelState,
+    selected_model: Option<&SelectedModel>,
+    daemon_model_id: Option<&str>,
+) -> Vec<LocalModelEntry> {
+    let mut entries: Vec<LocalModelEntry> = local_state
+        .custom_models
+        .iter()
+        .map(|entry| {
+            local_model_entry_from_registry_entry(entry, &[], selected_model, daemon_model_id)
+        })
+        .map(|mut entry| {
+            entry.group_id = Some("Custom models".to_string());
+            entry
+        })
+        .collect();
+
+    for provider_id in ["command", "http"] {
+        let Some(provider_config) = config.provider_configs.get(provider_id) else {
+            continue;
+        };
+        for (profile_id, profile) in &provider_config.models {
+            let description = match provider_id {
+                "command" => profile
+                    .settings
+                    .command
+                    .clone()
+                    .unwrap_or_else(|| "External command backend".to_string()),
+                "http" => profile
+                    .settings
+                    .endpoint
+                    .clone()
+                    .unwrap_or_else(|| "OpenAI-compatible HTTP endpoint".to_string()),
+                _ => String::new(),
+            };
+            entries.push(LocalModelEntry {
+                id: profile_id.clone(),
+                provider_id: provider_id.to_string(),
+                name: profile
+                    .settings
+                    .display_name
+                    .clone()
+                    .unwrap_or_else(|| profile_id.clone()),
+                description,
+                size_mb: 0,
+                is_downloaded: true,
+                is_active: selected_model
+                    .map(|selected| {
+                        selected.provider_id == provider_id && selected.model_id == *profile_id
+                    })
+                    .unwrap_or(false),
+                is_daemon_loaded: false,
+                is_available_in_registry: false,
+                languages: vec!["Configured".to_string()],
+                url: String::new(),
+                recommended_hardware: None,
+                category: None,
+                sha256: None,
+                group_id: Some("Custom models".to_string()),
+            });
+        }
+    }
+
+    entries
+}
+
+fn build_cloud_model_entries(
+    authorized_provider_ids: &[String],
+    selected_model: Option<&SelectedModel>,
+) -> Vec<LocalModelEntry> {
+    let authorized: std::collections::HashSet<&str> =
+        authorized_provider_ids.iter().map(String::as_str).collect();
+
+    TranscriptionProvider::all()
+        .iter()
+        .filter(|provider| provider.requires_auth())
+        .filter(|provider| authorized.contains(provider.id()))
+        .flat_map(|provider| transcription::models_for_provider(provider))
+        .map(|model| LocalModelEntry {
+            id: model.model_id.to_string(),
+            provider_id: model.provider_id.to_string(),
+            name: model.display_name.to_string(),
+            description: model.description.to_string(),
+            size_mb: 0,
+            is_downloaded: true,
+            is_active: selected_model
+                .map(|selected| {
+                    selected.provider_id == model.provider_id && selected.model_id == model.model_id
+                })
+                .unwrap_or(false),
+            is_daemon_loaded: false,
+            is_available_in_registry: false,
+            languages: model
+                .languages
+                .iter()
+                .map(|language| language.to_string())
+                .collect(),
+            url: String::new(),
+            recommended_hardware: None,
+            category: None,
+            sha256: None,
+            group_id: Some("Cloud models".to_string()),
         })
         .collect()
+}
+
+pub(crate) fn build_local_model_entries(
+    local_state: &LocalModelState,
+    registry: &[RegistryEntry],
+    selected_model: Option<&SelectedModel>,
+    daemon_model_id: Option<&str>,
+) -> Vec<LocalModelEntry> {
+    let _ = local_state;
+    registry
+        .iter()
+        .map(|entry| {
+            local_model_entry_from_registry_entry(entry, registry, selected_model, daemon_model_id)
+        })
+        .collect()
+}
+
+fn local_model_entry_from_registry_entry(
+    entry: &RegistryEntry,
+    registry: &[RegistryEntry],
+    selected_model: Option<&SelectedModel>,
+    daemon_model_id: Option<&str>,
+) -> LocalModelEntry {
+    let is_downloaded = model_destination(entry).exists();
+    let is_active = selected_model
+        .map(|selected| selected.provider_id == entry.provider_id && selected.model_id == entry.id)
+        .unwrap_or(false);
+    let is_daemon_loaded = daemon_model_id == Some(entry.id.as_str());
+
+    LocalModelEntry {
+        id: entry.id.clone(),
+        provider_id: entry.provider_id.clone(),
+        name: entry.name.clone(),
+        description: entry.description.clone(),
+        size_mb: entry.size_mb,
+        is_downloaded,
+        is_active,
+        is_daemon_loaded,
+        is_available_in_registry: registry
+            .iter()
+            .any(|registry_entry| registry_entry.id == entry.id),
+        languages: entry.languages.clone(),
+        url: entry.url.clone(),
+        recommended_hardware: entry.recommended_hardware.clone(),
+        category: entry.category.clone(),
+        sha256: entry.sha256.clone(),
+        group_id: Some("Local models".to_string()),
+    }
 }
 
 fn downloaded_model_disk_usage_bytes(entries: &[LocalModelEntry]) -> u64 {
     entries
         .iter()
+        .filter(|entry| entry.provider_id == "whisper")
         .filter(|entry| entry.is_downloaded)
         .filter_map(|entry| {
             model_destination(&registry_entry_from_model(entry))
@@ -260,7 +408,9 @@ async fn handle_key(
         (LocalModelsMode::ErrorDialog { .. }, KeyCode::Enter | KeyCode::Esc) => {
             tui.close_error_dialog()
         }
-        (LocalModelsMode::Browse, KeyCode::Char('x') | KeyCode::Delete) => tui.confirm_delete(),
+        (LocalModelsMode::Browse, KeyCode::Char('x') | KeyCode::Char('d') | KeyCode::Delete) => {
+            tui.confirm_delete()
+        }
         (LocalModelsMode::Info { .. }, KeyCode::Esc | KeyCode::Char('q')) => tui.back_to_browse(),
         (LocalModelsMode::Downloading(_), KeyCode::Enter | KeyCode::Tab | KeyCode::Esc) => {
             cancel_download(running_download)
@@ -375,7 +525,7 @@ async fn handle_selected_entry(
     };
     tracing::debug!("Selected local model '{}'", entry.id);
 
-    if !entry.is_downloaded {
+    if entry.provider_id == "whisper" && !entry.is_downloaded {
         if entry.is_available_in_registry {
             tracing::debug!("Confirming download for local model '{}'", entry.id);
             tui.mode = LocalModelsMode::ConfirmDownload {
@@ -403,6 +553,11 @@ async fn handle_selected_entry(
 }
 
 async fn activate_entry(entry: &LocalModelEntry) -> anyhow::Result<()> {
+    if entry.provider_id != "whisper" {
+        config::save_selected_model(&entry.provider_id, &entry.id)?;
+        return Ok(());
+    }
+
     if !entry.is_downloaded {
         anyhow::bail!("Download first with [d]");
     }
@@ -782,7 +937,7 @@ mod tests {
     }
 
     #[test]
-    fn build_local_model_entries_merges_registry_and_custom_entries() {
+    fn build_model_entries_orders_custom_before_local_entries() {
         with_isolated_models_dir(|_| {
             let registry = vec![registry_entry("turbo")];
             let state = LocalModelState {
@@ -793,10 +948,15 @@ mod tests {
                     ..registry_entry("custom")
                 }],
             };
+            let config = config::OsttConfig::default();
 
-            let entries = build_local_model_entries(&state, &registry, None, None);
+            let entries = build_model_entries(&config, &[], &state, &registry, None, None);
 
             assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].id, "custom");
+            assert_eq!(entries[0].group_id.as_deref(), Some("Custom models"));
+            assert_eq!(entries[1].id, "turbo");
+            assert_eq!(entries[1].group_id.as_deref(), Some("Local models"));
             assert!(entries.iter().any(|entry| {
                 entry.id == "turbo" && entry.is_available_in_registry && !entry.is_downloaded
             }));
@@ -965,7 +1125,7 @@ mod tests {
                 group_id: None,
             },
         ];
-        let idx = grouped_display_index(entries.iter().collect(), "tiny", 0);
-        assert_eq!(idx, Some(1));
+        let idx = grouped_display_index(entries.iter().collect(), "whisper/tiny", 0);
+        assert_eq!(idx, Some(2));
     }
 }

--- a/src/model/local_model_view/types.rs
+++ b/src/model/local_model_view/types.rs
@@ -137,7 +137,7 @@ impl LocalModelsTui {
     pub(crate) fn confirm_delete(&mut self) {
         if let Some(entry) = self
             .selected_entry()
-            .filter(|entry| entry.is_downloaded)
+            .filter(|entry| entry.provider_id == "whisper" && entry.is_downloaded)
             .cloned()
         {
             self.mode = LocalModelsMode::ConfirmDelete {
@@ -177,8 +177,13 @@ impl LocalModelsTui {
         registry: &[RegistryEntry],
     ) -> anyhow::Result<()> {
         let selected_model = crate::config::get_selected_model_entry()?;
+        let config = crate::config::OsttConfig::load()
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        let authorized_provider_ids = crate::config::get_authorized_providers()?;
         let daemon_model_id = self.daemon_model_id.as_deref();
-        self.entries = super::build_local_model_entries(
+        self.entries = super::build_model_entries(
+            &config,
+            &authorized_provider_ids,
             local_state,
             registry,
             selected_model.as_ref(),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,9 +1,5 @@
-mod cloud_model_info_view;
-mod cloud_model_view;
 mod local_model_view;
-mod model_provider_view;
 mod model_view;
-mod no_cloud_providers_view;
 
 pub use model_view::ModelView;
 
@@ -18,45 +14,82 @@ impl std::fmt::Display for UserQuit {
 
 impl std::error::Error for UserQuit {}
 
-pub(crate) use crate::ui::is_ctrl_c;
-
 #[cfg(test)]
 mod tests {
-    use super::cloud_model_view::{build_cloud_provider_sections, save_cloud_selection};
+    use super::local_model_view::build_model_entries;
+    use crate::transcription::local_models::LocalModelState;
 
     #[test]
-    fn cloud_sections_include_only_authenticated_providers() {
-        let sections =
-            build_cloud_provider_sections(&["openai".to_string(), "local".to_string()], None);
+    fn unified_model_entries_include_only_authenticated_cloud_providers() {
+        let config = crate::config::OsttConfig::default();
+        let entries = build_model_entries(
+            &config,
+            &["openai".to_string(), "local".to_string()],
+            &LocalModelState::default(),
+            &[],
+            None,
+            None,
+        );
 
-        assert_eq!(sections.len(), 1);
-        assert_eq!(sections[0].title, "OpenAI");
-        assert!(sections[0]
-            .models
-            .iter()
-            .all(|entry| entry.provider_id == "openai"));
+        assert!(entries.iter().any(|entry| entry.provider_id == "openai"));
+        assert!(entries.iter().all(|entry| entry.provider_id != "local"));
     }
 
     #[test]
-    fn cloud_sections_mark_only_selected_provider_model_active() {
+    fn unified_model_entries_mark_only_selected_provider_model_active() {
         let selected = crate::config::SelectedModel {
             provider_id: "openai".to_string(),
             model_id: "whisper-1".to_string(),
         };
+        let config = crate::config::OsttConfig::default();
 
-        let sections = build_cloud_provider_sections(
+        let entries = build_model_entries(
+            &config,
             &["openai".to_string(), "groq".to_string()],
+            &LocalModelState::default(),
+            &[],
             Some(&selected),
+            None,
         );
 
-        let active_entries: Vec<_> = sections
-            .iter()
-            .flat_map(|section| section.models.iter())
-            .filter(|entry| entry.is_active)
-            .collect();
+        let active_entries: Vec<_> = entries.iter().filter(|entry| entry.is_active).collect();
         assert_eq!(active_entries.len(), 1);
         assert_eq!(active_entries[0].provider_id, "openai");
-        assert_eq!(active_entries[0].model_id, selected.model_id);
+        assert_eq!(active_entries[0].id, selected.model_id);
+    }
+
+    #[test]
+    fn unified_model_entries_include_configured_profiles_first() {
+        let mut config = crate::config::OsttConfig::default();
+        let mut http_profile = crate::config::ProviderModelConfig::default();
+        http_profile.settings.display_name = Some("Speaches".to_string());
+        http_profile.settings.endpoint =
+            Some("http://localhost:8000/v1/audio/transcriptions".to_string());
+        config
+            .provider_configs
+            .entry("http".to_string())
+            .or_default()
+            .models
+            .insert("speaches".to_string(), http_profile);
+        let selected = crate::config::SelectedModel {
+            provider_id: "http".to_string(),
+            model_id: "speaches".to_string(),
+        };
+
+        let entries = build_model_entries(
+            &config,
+            &[],
+            &LocalModelState::default(),
+            &[],
+            Some(&selected),
+            None,
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].group_id.as_deref(), Some("Custom models"));
+        assert_eq!(entries[0].provider_id, "http");
+        assert_eq!(entries[0].id, "speaches");
+        assert!(entries[0].is_active);
     }
 
     #[test]
@@ -78,7 +111,7 @@ mod tests {
         std::env::set_var("HOME", &dir);
         crate::transcription::local_models::set_test_models_dir(Some(dir.join("models")));
 
-        save_cloud_selection("openai", "whisper-1").expect("save cloud selection");
+        config::save_selected_model("openai", "whisper-1").expect("save cloud selection");
         let config = config::OsttConfig::load().expect("load config");
         assert_eq!(config.transcription.provider.as_deref(), Some("openai"));
         assert_eq!(config.transcription.model.as_deref(), Some("whisper-1"));

--- a/src/model/model_view.rs
+++ b/src/model/model_view.rs
@@ -6,7 +6,6 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io::{self, Stdout};
 
-use super::model_provider_view::ModelProviderChoice;
 use super::UserQuit;
 
 pub struct ModelView {
@@ -27,21 +26,7 @@ impl ModelView {
     pub async fn run(&mut self) -> anyhow::Result<()> {
         tracing::debug!("Model view started");
         loop {
-            let choice = super::model_provider_view::run(&mut self.terminal).await?;
-            let result = match choice {
-                ModelProviderChoice::Quit => {
-                    tracing::debug!("Model view exited from provider picker");
-                    break;
-                }
-                ModelProviderChoice::Local => {
-                    tracing::debug!("Opening local model view");
-                    super::local_model_view::run(&mut self.terminal).await
-                }
-                ModelProviderChoice::Cloud => {
-                    tracing::debug!("Opening cloud model view");
-                    super::cloud_model_view::run(&mut self.terminal).await
-                }
-            };
+            let result = super::local_model_view::run(&mut self.terminal).await;
             if let Err(e) = result {
                 if e.downcast_ref::<UserQuit>().is_some() {
                     tracing::debug!("Model view exited via Ctrl+C");
@@ -49,6 +34,7 @@ impl ModelView {
                 }
                 return Err(e);
             }
+            break;
         }
         Ok(())
     }

--- a/src/transcription/api/assemblyai.rs
+++ b/src/transcription/api/assemblyai.rs
@@ -202,7 +202,7 @@ pub(super) async fn transcribe(
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to create HTTP client: {e}"))?;
 
-    let base_url = config.endpoint;
+    let base_url = &config.endpoint;
 
     // Step 1: Upload audio with retry logic for transient failures
     let upload_url = upload_with_retry(&client, base_url, &config.api_key, audio_data).await?;

--- a/src/transcription/api/berget.rs
+++ b/src/transcription/api/berget.rs
@@ -214,7 +214,7 @@ pub(super) async fn transcribe(
         }
     }
 
-    let endpoint = config.endpoint;
+    let endpoint = &config.endpoint;
 
     tracing::debug!(
         "Berget API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",

--- a/src/transcription/api/command.rs
+++ b/src/transcription/api/command.rs
@@ -1,0 +1,94 @@
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::Command;
+
+use super::TranscriptionConfig;
+
+pub(super) async fn transcribe(
+    config: &TranscriptionConfig,
+    audio_path: &Path,
+) -> anyhow::Result<String> {
+    let command = config.endpoint.trim();
+    if command.is_empty() {
+        anyhow::bail!(
+            "external command profile '{}' has no command",
+            config.model_id
+        );
+    }
+
+    let expanded = command.replace("{audio_path}", &shell_quote_path(audio_path));
+    tracing::debug!("External command transcription: {expanded}");
+
+    let mut process = shell_command(&expanded);
+    process.kill_on_drop(true);
+    let child = process
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("failed to start external command: {err}"))?;
+
+    let output = if let Some(timeout_secs) = config.timeout_secs {
+        tokio::time::timeout(Duration::from_secs(timeout_secs), child.wait_with_output())
+            .await
+            .map_err(|_| anyhow::anyhow!("external command timed out after {timeout_secs}s"))??
+    } else {
+        child.wait_with_output().await?
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let summary = if stderr.is_empty() {
+            "no stderr".to_string()
+        } else {
+            stderr
+        };
+        anyhow::bail!(
+            "external command failed with status {}: {}",
+            output.status,
+            summary
+        );
+    }
+
+    let transcript = String::from_utf8(output.stdout)
+        .map_err(|err| anyhow::anyhow!("external command produced invalid UTF-8: {err}"))?
+        .trim()
+        .to_string();
+    if transcript.is_empty() {
+        anyhow::bail!("external backend produced no transcript");
+    }
+
+    Ok(transcript)
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn shell_command(command: &str) -> Command {
+    let mut process = Command::new("sh");
+    process.arg("-c").arg(command);
+    process
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut process = Command::new("cmd");
+    process.arg("/C").arg(command);
+    process
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_path_preserves_spaces_and_quotes() {
+        let quoted = shell_quote_path(Path::new("/tmp/audio file's clip.mp3"));
+
+        assert_eq!(quoted, "'/tmp/audio file'\\''s clip.mp3'");
+    }
+}

--- a/src/transcription/api/elevenlabs.rs
+++ b/src/transcription/api/elevenlabs.rs
@@ -317,7 +317,7 @@ pub(super) async fn transcribe(
     }
 
     let client = reqwest::Client::new();
-    let url = config.endpoint;
+    let url = &config.endpoint;
 
     tracing::debug!(
         "ElevenLabs API Call:\n  URL: {}\n  Method: POST\n  Model: {}\n  Keyterms: {:?}",

--- a/src/transcription/api/groq.rs
+++ b/src/transcription/api/groq.rs
@@ -164,7 +164,7 @@ pub(super) async fn transcribe(
         }
     }
 
-    let endpoint = config.endpoint;
+    let endpoint = &config.endpoint;
 
     tracing::debug!(
         "Groq API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",

--- a/src/transcription/api/http.rs
+++ b/src/transcription/api/http.rs
@@ -1,0 +1,157 @@
+use serde::Deserialize;
+use std::path::Path;
+use std::time::Duration;
+
+use indexmap::IndexMap;
+
+use super::{TranscriptionConfig, TranscriptionResponse};
+use crate::config::ModelOptionValue;
+use crate::transcription::model::{ModelOptionKind, ModelOptionSchema, ModelOptionSpec};
+
+const HTTP_OPTIONS: &[ModelOptionSpec] = &[
+    ModelOptionSpec {
+        name: "model",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "language",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "prompt",
+        kind: ModelOptionKind::String,
+    },
+    ModelOptionSpec {
+        name: "temperature",
+        kind: ModelOptionKind::Number,
+    },
+    ModelOptionSpec {
+        name: "response_format",
+        kind: ModelOptionKind::String,
+    },
+];
+
+pub(super) fn option_schema(_model_id: &str) -> Option<ModelOptionSchema> {
+    Some(ModelOptionSchema::new(HTTP_OPTIONS))
+}
+
+pub(super) fn validate_options(
+    full_model_id: &str,
+    options: &IndexMap<String, ModelOptionValue>,
+) -> anyhow::Result<()> {
+    super::validate_number_range(full_model_id, options, "temperature", 0.0..=1.0)?;
+    if let Some(value) = options.get("response_format") {
+        super::validate_string_value(full_model_id, "response_format", value, &["json"])?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct HttpTranscriptionResponse {
+    text: String,
+}
+
+pub(super) async fn transcribe(
+    config: &TranscriptionConfig,
+    audio_path: &Path,
+) -> anyhow::Result<String> {
+    let model = config.option_string("model").ok_or_else(|| {
+        anyhow::anyhow!(
+            "HTTP profile '{}' is missing required param 'model'. Configure [http.{}.params].model or pass --param model=...",
+            config.model_id,
+            config.model_id
+        )
+    })?;
+
+    let audio_data = std::fs::read(audio_path)
+        .map_err(|err| anyhow::anyhow!("failed to read audio file: {err}"))?;
+    let file_name = audio_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let file_part = reqwest::multipart::Part::bytes(audio_data)
+        .file_name(file_name)
+        .mime_str("application/octet-stream")
+        .map_err(|err| anyhow::anyhow!("failed to create file part for upload: {err}"))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", file_part)
+        .text("model", model.to_string());
+    let mut debug_params = vec![format!("model={model}")];
+
+    if let Some(language) = config.option_string("language") {
+        form = form.text("language", language.to_string());
+        debug_params.push(format!("language={language}"));
+    }
+    if let Some(prompt) = config.option_string("prompt") {
+        form = form.text("prompt", prompt.to_string());
+        debug_params.push(format!("prompt={prompt}"));
+    }
+    if let Some(temperature) = config.option_number("temperature") {
+        form = form.text("temperature", temperature.to_string());
+        debug_params.push(format!("temperature={temperature}"));
+    }
+    if let Some(response_format) = config.option_string("response_format") {
+        form = form.text("response_format", response_format.to_string());
+        debug_params.push(format!("response_format={response_format}"));
+    }
+
+    let mut client = reqwest::Client::builder();
+    if let Some(timeout_secs) = config.timeout_secs {
+        client = client.timeout(Duration::from_secs(timeout_secs));
+    }
+    let client = client.build()?;
+
+    tracing::debug!(
+        "OpenAI-compatible HTTP transcription:\n  URL: {}\n  Body parameters: {}",
+        config.endpoint,
+        debug_params.join("\n    ")
+    );
+
+    let mut request = client.post(&config.endpoint).multipart(form);
+    if config.api_key_configured {
+        request = request.bearer_auth(&config.api_key);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|err| anyhow::anyhow!("HTTP transcription request failed: {err}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        anyhow::bail!("HTTP transcription failed with status {status}: {body}");
+    }
+
+    let parsed: HttpTranscriptionResponse = response
+        .json()
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to parse HTTP transcription response: {err}"))?;
+    Ok(TranscriptionResponse { text: parsed.text }.text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_response_format_for_json_only_v1() {
+        let mut options = IndexMap::new();
+        options.insert(
+            "response_format".to_string(),
+            ModelOptionValue::String("text".to_string()),
+        );
+
+        let err = validate_options("http/speaches", &options)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("response_format"));
+        assert!(err.contains("json"));
+    }
+}

--- a/src/transcription/api/mistral.rs
+++ b/src/transcription/api/mistral.rs
@@ -155,7 +155,7 @@ pub(super) async fn transcribe(
         );
     }
 
-    let endpoint = config.endpoint;
+    let endpoint = &config.endpoint;
 
     let client = reqwest::Client::new();
 

--- a/src/transcription/api/mod.rs
+++ b/src/transcription/api/mod.rs
@@ -6,10 +6,12 @@
 
 mod assemblyai;
 mod berget;
+mod command;
 mod deepgram;
 mod deepinfra;
 mod elevenlabs;
 mod groq;
+mod http;
 pub(crate) mod local;
 mod mistral;
 mod openai;
@@ -31,9 +33,13 @@ pub struct TranscriptionConfig {
     /// The selected model ID, including data-driven local model IDs
     pub model_id: String,
     /// Base API endpoint for the selected model
-    pub endpoint: &'static str,
+    pub endpoint: String,
     /// The API key for authentication
     pub api_key: String,
+    /// Whether auth should be sent when the key is empty
+    pub api_key_configured: bool,
+    /// Provider request timeout in seconds
+    pub timeout_secs: Option<u64>,
     /// Keywords to improve transcription accuracy
     pub keywords: Vec<String>,
     /// Validated request params for the selected model
@@ -45,7 +51,7 @@ impl TranscriptionConfig {
     pub fn new_cloud(
         provider: TranscriptionProvider,
         model_id: String,
-        endpoint: &'static str,
+        endpoint: impl Into<String>,
         api_key: String,
         keywords: Vec<String>,
         params: IndexMap<String, ModelOptionValue>,
@@ -53,8 +59,31 @@ impl TranscriptionConfig {
         Self {
             provider,
             model_id,
-            endpoint,
+            endpoint: endpoint.into(),
             api_key,
+            api_key_configured: true,
+            timeout_secs: None,
+            keywords,
+            params,
+        }
+    }
+
+    pub fn new_external(
+        provider: TranscriptionProvider,
+        model_id: String,
+        endpoint: String,
+        api_key: Option<String>,
+        timeout_secs: Option<u64>,
+        keywords: Vec<String>,
+        params: IndexMap<String, ModelOptionValue>,
+    ) -> Self {
+        Self {
+            provider,
+            model_id,
+            endpoint,
+            api_key_configured: api_key.is_some(),
+            api_key: api_key.unwrap_or_default(),
+            timeout_secs,
             keywords,
             params,
         }
@@ -69,8 +98,10 @@ impl TranscriptionConfig {
         Self {
             provider: TranscriptionProvider::Whisper,
             model_id,
-            endpoint: "",
+            endpoint: String::new(),
             api_key: String::new(),
+            api_key_configured: false,
+            timeout_secs: None,
             keywords,
             params,
         }
@@ -156,6 +187,8 @@ pub async fn transcribe(config: &TranscriptionConfig, audio_path: &Path) -> anyh
         TranscriptionProvider::ElevenLabs => elevenlabs::transcribe(config, audio_path).await,
         TranscriptionProvider::Whisper => local::transcribe(config, audio_path).await,
         TranscriptionProvider::Mistral => mistral::transcribe(config, audio_path).await,
+        TranscriptionProvider::Command => command::transcribe(config, audio_path).await,
+        TranscriptionProvider::Http => http::transcribe(config, audio_path).await,
     }?;
 
     Ok(result)
@@ -172,6 +205,7 @@ pub(crate) fn option_schema(provider_id: &str, model_id: &str) -> Option<ModelOp
         "elevenlabs" => elevenlabs::option_schema(model_id),
         "mistral" => mistral::option_schema(model_id),
         "whisper" => local::option_schema(model_id),
+        "http" => http::option_schema(model_id),
         _ => None,
     }
 }
@@ -190,6 +224,7 @@ pub(crate) fn validate_params(
         "elevenlabs" => elevenlabs::validate_options(full_model_id, options),
         "mistral" => mistral::validate_options(full_model_id, options),
         "whisper" => local::validate_options(full_model_id, options),
+        "http" => http::validate_options(full_model_id, options),
         _ => Ok(()),
     }
 }

--- a/src/transcription/api/openai.rs
+++ b/src/transcription/api/openai.rs
@@ -272,8 +272,7 @@ pub(super) async fn transcribe(
         );
     }
 
-    let endpoint = config.endpoint;
-    let url = endpoint.to_string();
+    let url = config.endpoint.clone();
 
     tracing::debug!(
         "OpenAI API Call:\n  URL: {}\n  Method: POST\n  Headers:\n    Authorization: Bearer <redacted>\n    Content-Type: multipart/form-data\n  Body parameters: {}",

--- a/src/transcription/context.rs
+++ b/src/transcription/context.rs
@@ -58,7 +58,6 @@ fn config_for_selected_model(
     keywords: Vec<String>,
     param_overrides: &[String],
 ) -> anyhow::Result<TranscriptionConfig> {
-    let api_key = config::get_api_key(&selected_model.provider_id)?;
     let mut params = ostt_config
         .provider_configs
         .get(&selected_model.provider_id)
@@ -78,13 +77,17 @@ fn config_for_selected_model(
         &params,
     )?;
 
-    super::config_for_selected_model(selected_model, api_key, keywords, params)
+    super::config_for_selected_model(ostt_config, selected_model, keywords, params)
 }
 
 fn parse_param_overrides(
     selected_model: &SelectedModel,
     overrides: &[String],
 ) -> anyhow::Result<IndexMap<String, config::ModelOptionValue>> {
+    if overrides.is_empty() {
+        return Ok(IndexMap::new());
+    }
+
     let schema = super::api::option_schema(&selected_model.provider_id, &selected_model.model_id)
         .ok_or_else(|| anyhow::anyhow!("No params are supported for this model"))?;
     let full_model_id = format!("{}/{}", selected_model.provider_id, selected_model.model_id);
@@ -207,6 +210,14 @@ mod tests {
 
         assert!(err.contains("Invalid --param 'diarize'"));
         assert!(err.contains("key=value"));
+    }
+
+    #[test]
+    fn param_overrides_allow_empty_overrides_for_paramless_models() {
+        let model = selected_model("command", "parakeet");
+        let options = parse_param_overrides(&model, &[]).unwrap();
+
+        assert!(options.is_empty());
     }
 
     #[test]

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -26,8 +26,8 @@ pub use model::{all_models, find_model, models_for_provider, ModelOptionKind, Mo
 pub use provider::TranscriptionProvider;
 
 pub fn config_for_selected_model(
+    ostt_config: &crate::config::OsttConfig,
     selected_model: &crate::config::SelectedModel,
-    api_key: Option<String>,
     keywords: Vec<String>,
     params: indexmap::IndexMap<String, crate::config::ModelOptionValue>,
 ) -> anyhow::Result<TranscriptionConfig> {
@@ -48,6 +48,32 @@ pub fn config_for_selected_model(
         ));
     }
 
+    if provider == TranscriptionProvider::Command {
+        let profile = external_profile_config(ostt_config, selected_model)?;
+        return Ok(TranscriptionConfig::new_external(
+            provider,
+            selected_model.model_id.clone(),
+            profile.settings.command.clone().unwrap_or_default(),
+            None,
+            profile.settings.timeout_secs,
+            keywords,
+            params,
+        ));
+    }
+
+    if provider == TranscriptionProvider::Http {
+        let profile = external_profile_config(ostt_config, selected_model)?;
+        return Ok(TranscriptionConfig::new_external(
+            provider,
+            selected_model.model_id.clone(),
+            profile.settings.endpoint.clone().unwrap_or_default(),
+            profile.settings.api_key.clone(),
+            profile.settings.timeout_secs,
+            keywords,
+            params,
+        ));
+    }
+
     let model = find_model(&selected_model.provider_id, &selected_model.model_id).ok_or_else(|| {
         anyhow::anyhow!(
             "Unknown model '{}' for provider '{}'. Please run 'ostt model' to select a supported model.",
@@ -56,7 +82,7 @@ pub fn config_for_selected_model(
         )
     })?;
 
-    let api_key = api_key.ok_or_else(|| {
+    let api_key = crate::config::get_api_key(&selected_model.provider_id)?.ok_or_else(|| {
         anyhow::anyhow!("No API key for {}. Please run 'ostt auth'", provider.name())
     })?;
 
@@ -68,6 +94,23 @@ pub fn config_for_selected_model(
         keywords,
         params,
     ))
+}
+
+fn external_profile_config<'a>(
+    ostt_config: &'a crate::config::OsttConfig,
+    selected_model: &crate::config::SelectedModel,
+) -> anyhow::Result<&'a crate::config::ProviderModelConfig> {
+    ostt_config
+        .provider_configs
+        .get(&selected_model.provider_id)
+        .and_then(|provider| provider.models.get(&selected_model.model_id))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown external profile: {}/{}",
+                selected_model.provider_id,
+                selected_model.model_id
+            )
+        })
 }
 
 pub(crate) fn local_inference_backend() -> &'static str {

--- a/src/transcription/provider.rs
+++ b/src/transcription/provider.rs
@@ -17,6 +17,8 @@ pub enum TranscriptionProvider {
     ElevenLabs,
     Whisper,
     Mistral,
+    Command,
+    Http,
 }
 
 impl TranscriptionProvider {
@@ -31,6 +33,8 @@ impl TranscriptionProvider {
             TranscriptionProvider::ElevenLabs => "elevenlabs",
             TranscriptionProvider::Whisper => "whisper",
             TranscriptionProvider::Mistral => "mistral",
+            TranscriptionProvider::Command => "command",
+            TranscriptionProvider::Http => "http",
         }
     }
 
@@ -45,6 +49,8 @@ impl TranscriptionProvider {
             TranscriptionProvider::ElevenLabs => "ElevenLabs",
             TranscriptionProvider::Whisper => "Whisper (local whisper.cpp)",
             TranscriptionProvider::Mistral => "Mistral",
+            TranscriptionProvider::Command => "External command",
+            TranscriptionProvider::Http => "OpenAI-compatible HTTP",
         }
     }
 
@@ -59,6 +65,8 @@ impl TranscriptionProvider {
             "elevenlabs" => Some(TranscriptionProvider::ElevenLabs),
             "whisper" => Some(TranscriptionProvider::Whisper),
             "mistral" => Some(TranscriptionProvider::Mistral),
+            "command" => Some(TranscriptionProvider::Command),
+            "http" => Some(TranscriptionProvider::Http),
             _ => None,
         }
     }
@@ -74,10 +82,21 @@ impl TranscriptionProvider {
             TranscriptionProvider::ElevenLabs,
             TranscriptionProvider::Whisper,
             TranscriptionProvider::Mistral,
+            TranscriptionProvider::Command,
+            TranscriptionProvider::Http,
         ]
     }
 
     pub fn supported_ids() -> Vec<&'static str> {
         Self::all().iter().map(Self::id).collect()
+    }
+
+    pub fn requires_auth(&self) -> bool {
+        !matches!(
+            self,
+            TranscriptionProvider::Whisper
+                | TranscriptionProvider::Command
+                | TranscriptionProvider::Http
+        )
     }
 }

--- a/src/ui/components/dialog.rs
+++ b/src/ui/components/dialog.rs
@@ -27,7 +27,7 @@ pub fn render_dialog(
             .bg(Color::White)
             .add_modifier(Modifier::BOLD),
     )));
-    render_dialog_content(frame, title, lines, 70, 9);
+    render_dialog_content(frame, title, lines, 70, 10);
 }
 
 pub fn centered_fixed_rect(width: u16, height: u16, area: Rect) -> Rect {


### PR DESCRIPTION
## Summary
- add first-class command/* and http/* transcription providers
- validate external provider config, params, and command placeholders
- expose external profiles in model list/select and the unified model picker
- keep auth flows scoped to credentialed cloud providers

## Verification
- cargo fmt --check
- cargo check
- cargo test --lib