### PR TITLE
feat: warn users when active provider does not fully support keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ OSTT is built for people who treat the terminal as a normal place for voice inpu
 - **Scriptable post-processing** - Transform transcripts with AI prompts or bash commands using `ostt -p` and `ostt process`.
 - **Retry without re-recording** - Save recordings locally, then re-transcribe them with a different provider or model.
 - **File transcription and replay** - Transcribe existing audio files and replay saved recordings from history.
-- **Keywords and custom vocabulary** - Improve recognition for names, technical terms, and project-specific language.
+- **Keywords and custom vocabulary** - Improve recognition for names, technical terms, and project-specific language. Keyword support varies by provider: Deepgram offers the most complete support, while Whisper-based (local) models do not support keywords.
 - **Open source, no subscription** - Public code, local configuration, and no vendor lock-in beyond the providers you choose.
 
 ## Documentation

--- a/src/commands/keywords.rs
+++ b/src/commands/keywords.rs
@@ -8,12 +8,21 @@ use anyhow::Result;
 /// Handles the keywords management command.
 ///
 /// Shows a TUI for viewing, adding, and removing keywords.
+/// When the active transcription model is not a Deepgram model, displays a
+/// notice informing the user that keyword support may be limited.
 pub async fn handle_keywords() -> Result<()> {
     let config_dir = crate::app_dirs::config_dir();
 
+    // Determine whether the active model is Deepgram-backed.
+    // show_provider_warning = true means "not Deepgram → show the notice".
+    let show_provider_warning = crate::config::get_selected_model()
+        .unwrap_or(None)
+        .map(|m| !m.starts_with("deepgram"))
+        .unwrap_or(false); // no model selected → no warning (edge case)
+
     let mut manager = KeywordsManager::new(&config_dir)?;
 
-    let mut view = KeywordsView::new(manager.load_keywords()?)?;
+    let mut view = KeywordsView::new(manager.load_keywords()?, show_provider_warning)?;
     view.run(&mut manager)?;
 
     Ok(())

--- a/src/keywords/keywords_view.rs
+++ b/src/keywords/keywords_view.rs
@@ -35,6 +35,9 @@ pub struct KeywordsView {
     input: Input,
     /// Whether cleanup has been performed
     cleaned_up: bool,
+    /// Whether to show the provider compatibility warning.
+    /// True when the active transcription provider is not Deepgram.
+    show_provider_warning: bool,
 }
 
 impl KeywordsView {
@@ -42,10 +45,11 @@ impl KeywordsView {
     ///
     /// # Arguments
     /// * `keywords` - List of keywords to display
+    /// * `show_provider_warning` - Show a notice when the active provider is not Deepgram
     ///
     /// # Errors
     /// - If terminal cannot be initialized
-    pub fn new(keywords: Vec<String>) -> Result<Self> {
+    pub fn new(keywords: Vec<String>, show_provider_warning: bool) -> Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
         execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
@@ -65,6 +69,7 @@ impl KeywordsView {
             input_mode: false,
             input: Input::default(),
             cleaned_up: false,
+            show_provider_warning,
         })
     }
 
@@ -215,6 +220,7 @@ impl KeywordsView {
         let keywords = self.keywords.clone();
         let list_state = &mut self.list_state;
 
+        let show_provider_warning = self.show_provider_warning;
         self.terminal.draw(|frame| {
             let layout = render_app_layout(frame, frame.area());
             render_title(frame, layout.title, "Keywords");
@@ -230,7 +236,7 @@ impl KeywordsView {
                 );
                 render_footer(frame, layout.footer, "↵ add, esc cancel");
             } else {
-                Self::draw_normal(frame, layout.body, &keywords, list_state);
+                Self::draw_normal(frame, layout.body, &keywords, list_state, show_provider_warning);
                 render_footer(
                     frame,
                     layout.footer,
@@ -243,8 +249,33 @@ impl KeywordsView {
     }
 
     /// Draws the UI when *not* in input mode.
-    fn draw_normal(frame: &mut Frame, area: Rect, keywords: &[String], list_state: &mut ListState) {
-        Self::render_keywords_list(frame, area, keywords, list_state);
+    fn draw_normal(
+        frame: &mut Frame,
+        area: Rect,
+        keywords: &[String],
+        list_state: &mut ListState,
+        show_provider_warning: bool,
+    ) {
+        if show_provider_warning {
+            // Reserve one line at the bottom for the provider notice.
+            let layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(area);
+
+            Self::render_keywords_list(frame, layout[0], keywords, list_state);
+
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![Span::styled(
+                    "ℹ  The keywords feature works best with the Deepgram provider.",
+                    Style::default().fg(Color::Yellow),
+                )]))
+                .alignment(Alignment::Left),
+                layout[1],
+            );
+        } else {
+            Self::render_keywords_list(frame, area, keywords, list_state);
+        }
     }
 
     /// Draws the UI when in input mode.


### PR DESCRIPTION
## Summary

Closes #21.

The keywords feature works best with Deepgram. Whisper-based (local) models and some other providers have partial or no keyword support. This was not communicated to users at all — the Keywords screen appeared the same regardless of the configured provider.

## Changes

### `src/keywords/keywords_view.rs`
- Added `show_provider_warning: bool` field to `KeywordsView`.
- `draw_normal` now accepts the flag and, when true, renders a one-line yellow notice at the bottom of the Keywords screen:
  > ℹ  The keywords feature works best with the Deepgram provider.

### `src/commands/keywords.rs`
- `handle_keywords` calls `get_selected_model()` to read the active model.
- Sets `show_provider_warning = true` when the model string does not start with `"deepgram"`.

### `README.md`
- Expanded the keywords feature bullet to note that keyword support varies by provider and Whisper-based models do not support it.

## UX

The notice is non-blocking — a single dimmed line at the bottom. It does not interrupt the normal keyword management flow.