### PR TITLE
Add paste output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--paste` output mode for record, transcribe, retry, process, and launch flows, using configurable `[output.paste]` clipboard-backed paste settings.
 - Added deterministic text replace rules configured under `[text.replace]`, applied before processing/output/history, with an `ostt replace` TUI for managing rules.
 - Added external `command/<profile>` transcription providers that run configured shell commands with `{audio_path}` and read transcript text from stdout.
 - Added external `http/<profile>` transcription providers for OpenAI-compatible `/v1/audio/transcriptions` endpoints with validated request params.

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -52,6 +52,16 @@ output_format = "mp3 -ab 16k -ar 12000"
 # "typescript" = "TypeScript"
 # "github" = "GitHub"
 
+[output.paste]
+# Paste mode copies the final text to the clipboard, sends this shortcut,
+# then restores the previous clipboard when enabled.
+# Defaults: macOS uses cmd+v, Omarchy uses shift+insert, other Linux uses ctrl+v.
+# Linux paste shortcuts vary by app and desktop; override paste_key when needed.
+paste_key = "ctrl+v"
+restore_clipboard = true
+restore_delay_ms = 750
+post_popup_delay_ms = 1000
+
 # Provider and per-model transcription params.
 # Provider params apply to all models for that provider. Model params override provider params.
 #

--- a/src/app.rs
+++ b/src/app.rs
@@ -278,9 +278,6 @@ enum Commands {
     /// and common transcription corrections.
     Replace,
 
-    #[command(name = "__paste", hide = true)]
-    PasteHelper,
-
     /// Open configuration file in your preferred editor
     ///
     /// Edit audio settings, provider options, and other configuration.
@@ -595,6 +592,13 @@ fn resolve_process_args(
 /// - If logging initialization fails
 /// - If command execution fails (e.g., authentication, recording, history viewing)
 pub async fn run() -> Result<(), anyhow::Error> {
+    if env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("paste-helper")) {
+        logging::init_logging()?;
+        check_and_run_setup().await?;
+        let config_data = load_config()?;
+        return crate::paste::handle_paste_helper(&config_data);
+    }
+
     let cli = Cli::parse();
 
     // Handle commands that don't need logging or config setup
@@ -835,7 +839,6 @@ pub async fn run() -> Result<(), anyhow::Error> {
             }
         },
         Some(Commands::Replace) => commands::handle_replace().await?,
-        Some(Commands::PasteHelper) => crate::paste::handle_paste_helper(&config_data)?,
         Some(Commands::Config { command }) => match command {
             None => commands::handle_config()?,
             Some(ConfigCommand::Path) => commands::config::handle_config_path()?,
@@ -1155,6 +1158,16 @@ mod tests {
                 ..
             }) => assert_eq!(shell, Shell::Bash),
             _ => panic!("expected completions install command"),
+        }
+    }
+
+    #[test]
+    fn cli_generates_shell_completions_without_panicking() {
+        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
+            let mut output = Vec::new();
+            generate(shell, &mut Cli::command(), "ostt", &mut output);
+            assert!(!output.is_empty());
+            assert!(!String::from_utf8_lossy(&output).contains("paste-helper"));
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -89,6 +89,10 @@ struct Cli {
     #[arg(short, long)]
     clipboard: bool,
 
+    /// Paste transcription into the focused app (record default command)
+    #[arg(long)]
+    paste: bool,
+
     /// Write transcription to file instead of stdout (record default command)
     #[arg(short, long, value_name = "FILE")]
     output: Option<String>,
@@ -133,6 +137,10 @@ enum Commands {
         #[arg(short, long)]
         clipboard: bool,
 
+        /// Paste transcription into the focused app
+        #[arg(long)]
+        paste: bool,
+
         /// Write transcription to file instead of stdout
         #[arg(short, long, value_name = "FILE")]
         output: Option<String>,
@@ -158,6 +166,10 @@ enum Commands {
         /// Copy transcription to clipboard instead of stdout
         #[arg(short, long)]
         clipboard: bool,
+
+        /// Paste transcription into the focused app
+        #[arg(long)]
+        paste: bool,
 
         /// Write transcription to file instead of stdout
         #[arg(short, long, value_name = "FILE")]
@@ -191,6 +203,10 @@ enum Commands {
         /// Copy transcription to clipboard instead of stdout
         #[arg(short, long)]
         clipboard: bool,
+
+        /// Paste transcription into the focused app
+        #[arg(long)]
+        paste: bool,
 
         /// Write transcription to file instead of stdout
         #[arg(short, long, value_name = "FILE")]
@@ -262,6 +278,9 @@ enum Commands {
     /// and common transcription corrections.
     Replace,
 
+    #[command(name = "__paste", hide = true)]
+    PasteHelper,
+
     /// Open configuration file in your preferred editor
     ///
     /// Edit audio settings, provider options, and other configuration.
@@ -302,6 +321,10 @@ enum Commands {
         /// Copy result to clipboard instead of stdout (shadows global -c)
         #[arg(short, long)]
         clipboard: bool,
+
+        /// Paste result into the focused app
+        #[arg(long)]
+        paste: bool,
 
         /// Write result to file instead of stdout (shadows global -o)
         #[arg(short, long, value_name = "FILE")]
@@ -663,16 +686,18 @@ pub async fn run() -> Result<(), anyhow::Error> {
             // Default command is record
             // Merge top-level options with explicit record command options
             // If both are specified, the explicit record command options take precedence
-            let (clipboard, output, process, model) = match cli.command {
+            let (clipboard, paste, output, process, model) = match cli.command {
                 Some(Commands::Record {
                     clipboard,
+                    paste,
                     output,
                     process,
                     model,
-                }) => (clipboard, output, process, model.or(cli.model)),
-                None => (cli.clipboard, cli.output, cli.process, cli.model),
+                }) => (clipboard, paste, output, process, model.or(cli.model)),
+                None => (cli.clipboard, cli.paste, cli.output, cli.process, cli.model),
                 _ => unreachable!(),
             };
+            ensure_single_output_mode(clipboard, paste, output.as_ref())?;
             let model_override = model
                 .as_deref()
                 .map(crate::config::parse_provider_model)
@@ -680,6 +705,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             commands::handle_record(
                 &config_data,
                 clipboard,
+                paste,
                 output,
                 process,
                 model_override,
@@ -690,10 +716,12 @@ pub async fn run() -> Result<(), anyhow::Error> {
         Some(Commands::Retry {
             index,
             clipboard,
+            paste,
             output,
             process,
             model,
         }) => {
+            ensure_single_output_mode(clipboard, paste, output.as_ref())?;
             let model_override = model
                 .or(cli.model)
                 .as_deref()
@@ -703,6 +731,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 &config_data,
                 index,
                 clipboard,
+                paste,
                 output,
                 process,
                 model_override,
@@ -713,10 +742,12 @@ pub async fn run() -> Result<(), anyhow::Error> {
         Some(Commands::Transcribe {
             file,
             clipboard,
+            paste,
             output,
             process,
             model,
         }) => {
+            ensure_single_output_mode(clipboard, paste, output.as_ref())?;
             let model_override = model
                 .or(cli.model)
                 .as_deref()
@@ -726,6 +757,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
                 &config_data,
                 file,
                 clipboard,
+                paste,
                 output,
                 process,
                 model_override,
@@ -803,6 +835,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             }
         },
         Some(Commands::Replace) => commands::handle_replace().await?,
+        Some(Commands::PasteHelper) => crate::paste::handle_paste_helper(&config_data)?,
         Some(Commands::Config { command }) => match command {
             None => commands::handle_config()?,
             Some(ConfigCommand::Path) => commands::config::handle_config_path()?,
@@ -820,13 +853,17 @@ pub async fn run() -> Result<(), anyhow::Error> {
             index_or_action,
             action,
             clipboard,
+            paste,
             output,
             ..
         }) => {
+            ensure_single_output_mode(clipboard, paste, output.as_ref())?;
             let (index, action) = resolve_process_args(index_or_action, action)?;
-            commands::handle_process(&config_data, index, action, false, clipboard, output).await?;
+            commands::handle_process(&config_data, index, action, false, clipboard, paste, output)
+                .await?;
         }
         Some(Commands::Launch { args }) => {
+            ensure_single_output_mode(cli.clipboard, cli.paste, cli.output.as_ref())?;
             // Reconstruct the full ostt args list. Global flags (-c, -o, -p) are
             // consumed by clap before they reach the Launch args vec, so we
             // re-inject them here so they get passed to the spawned ostt instance.
@@ -839,6 +876,9 @@ pub async fn run() -> Result<(), anyhow::Error> {
             }
             if cli.clipboard {
                 full_args.insert(0, "-c".to_string());
+            }
+            if cli.paste {
+                full_args.insert(0, "--paste".to_string());
             }
             if let Some(ref out) = cli.output {
                 full_args.insert(0, out.clone());
@@ -904,6 +944,18 @@ fn completion_filename(shell: Shell) -> String {
         Shell::PowerShell => "ostt.ps1".to_string(),
         _ => "ostt".to_string(),
     }
+}
+
+fn ensure_single_output_mode(
+    clipboard: bool,
+    paste: bool,
+    output: Option<&String>,
+) -> anyhow::Result<()> {
+    let selected = usize::from(clipboard) + usize::from(paste) + usize::from(output.is_some());
+    if selected > 1 {
+        anyhow::bail!("Choose one output mode: stdout, --clipboard, --output, or --paste.");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1009,6 +1061,58 @@ mod tests {
             Some(Commands::Replace) => {}
             _ => panic!("expected replace command"),
         }
+    }
+
+    #[test]
+    fn cli_accepts_paste_for_output_commands() {
+        let cli = Cli::try_parse_from(["ostt", "--paste"]).expect("parse cli");
+        assert!(cli.paste);
+
+        let cli = Cli::try_parse_from(["ostt", "record", "--paste"]).expect("parse cli");
+        match cli.command {
+            Some(Commands::Record { paste, .. }) => assert!(paste),
+            _ => panic!("expected record command"),
+        }
+
+        let cli =
+            Cli::try_parse_from(["ostt", "transcribe", "audio.ogg", "--paste"]).expect("parse cli");
+        match cli.command {
+            Some(Commands::Transcribe { paste, .. }) => assert!(paste),
+            _ => panic!("expected transcribe command"),
+        }
+
+        let cli = Cli::try_parse_from(["ostt", "retry", "--paste"]).expect("parse cli");
+        match cli.command {
+            Some(Commands::Retry { paste, .. }) => assert!(paste),
+            _ => panic!("expected retry command"),
+        }
+
+        let cli = Cli::try_parse_from(["ostt", "process", "clean", "--paste"]).expect("parse cli");
+        match cli.command {
+            Some(Commands::Process { paste, .. }) => assert!(paste),
+            _ => panic!("expected process command"),
+        }
+    }
+
+    #[test]
+    fn cli_forwards_paste_for_launch() {
+        let cli =
+            Cli::try_parse_from(["ostt", "launch", "--paste", "-p", "clean"]).expect("parse cli");
+
+        match cli.command {
+            Some(Commands::Launch { args }) => {
+                assert_eq!(args, ["--paste", "-p", "clean"]);
+            }
+            _ => panic!("expected launch command"),
+        }
+    }
+
+    #[test]
+    fn output_mode_validation_rejects_ambiguous_modes() {
+        assert!(ensure_single_output_mode(true, true, None).is_err());
+        assert!(ensure_single_output_mode(false, true, Some(&"out.txt".to_string())).is_err());
+        assert!(ensure_single_output_mode(true, false, Some(&"out.txt".to_string())).is_err());
+        assert!(ensure_single_output_mode(false, true, None).is_ok());
     }
 
     #[test]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -2,6 +2,7 @@
 //!
 //! Handles copying transcribed text to system clipboard using pbcopy (macOS), wl-copy (Wayland), or xclip (X11).
 
+use anyhow::Context;
 use std::io::Write;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -88,5 +89,76 @@ pub fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
     tracing::warn!("No clipboard tool available (pbcopy not found)");
     #[cfg(not(target_os = "macos"))]
     tracing::warn!("No clipboard tool available (wl-copy or xclip not found)");
+    Ok(())
+}
+
+pub(crate) fn read_clipboard() -> anyhow::Result<String> {
+    #[cfg(target_os = "macos")]
+    {
+        return read_command("pbpaste", &[]);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if std::env::var("WAYLAND_DISPLAY").is_ok() {
+            if let Ok(text) = read_command("wl-paste", &["--no-newline"]) {
+                return Ok(text);
+            }
+        }
+
+        read_command("xclip", &["-selection", "clipboard", "-out"])
+    }
+}
+
+pub(crate) fn set_clipboard(text: &str) -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return write_command("pbcopy", &[], text);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if std::env::var("WAYLAND_DISPLAY").is_ok() {
+            if write_command("wl-copy", &["--type", "text/plain", "--trim-newline"], text).is_ok() {
+                return Ok(());
+            }
+        }
+
+        write_command("xclip", &["-selection", "clipboard", "-in", "-quiet"], text)
+    }
+}
+
+fn read_command(program: &str, args: &[&str]) -> anyhow::Result<String> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("Failed to run {program}"))?;
+    if !output.status.success() {
+        anyhow::bail!("{program} failed with status {}", output.status);
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn write_command(program: &str, args: &[&str], text: &str) -> anyhow::Result<()> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("Failed to run {program}"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("Failed to open {program} stdin"))?;
+    stdin
+        .write_all(text.as_bytes())
+        .with_context(|| format!("Failed to write to {program}"))?;
+    drop(stdin);
+
+    let status = child
+        .wait()
+        .with_context(|| format!("Failed to wait for {program}"))?;
+    if !status.success() {
+        anyhow::bail!("{program} failed with status {status}");
+    }
     Ok(())
 }

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -171,6 +171,7 @@ fn build_terminal_args(
 
             let mut args = vec![
                 binary.to_string(),
+                "--class=ostt-popup".to_string(),
                 "--title=ostt".to_string(),
                 format!("--window-position-x={}", config.x),
                 format!("--window-position-y={}", config.y),
@@ -365,20 +366,5 @@ mod tests {
             .iter()
             .any(|arg| arg == "macos_quit_when_last_window_closed=yes"));
         assert_eq!(args.last(), Some(&"-c".to_string()));
-    }
-
-    #[test]
-    fn ghostty_args_do_not_use_invalid_class_flag() {
-        let args = build_terminal_args(
-            TerminalEmulator::Ghostty,
-            "ghostty",
-            &PopupConfig::default(),
-            "ostt",
-            &["--paste".to_string()],
-        );
-
-        assert!(!args.iter().any(|arg| arg == "--class=ostt-popup"));
-        assert!(args.iter().any(|arg| arg == "--title=ostt"));
-        assert!(args.last().is_some_and(|arg| arg.contains("'--paste'")));
     }
 }

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -5,7 +5,7 @@
 //! a new instance.
 
 use anyhow::{anyhow, Context};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::config::file::PopupConfig;
 use crate::recording::active;
@@ -171,7 +171,6 @@ fn build_terminal_args(
 
             let mut args = vec![
                 binary.to_string(),
-                "--class=ostt-popup".to_string(),
                 "--title=ostt".to_string(),
                 format!("--window-position-x={}", config.x),
                 format!("--window-position-y={}", config.y),
@@ -325,6 +324,9 @@ pub async fn handle_launch(
 
     let child = Command::new(program)
         .args(spawn_args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .with_context(|| format!("Failed to spawn {}", terminal.command_name()))?;
 
@@ -363,5 +365,20 @@ mod tests {
             .iter()
             .any(|arg| arg == "macos_quit_when_last_window_closed=yes"));
         assert_eq!(args.last(), Some(&"-c".to_string()));
+    }
+
+    #[test]
+    fn ghostty_args_do_not_use_invalid_class_flag() {
+        let args = build_terminal_args(
+            TerminalEmulator::Ghostty,
+            "ghostty",
+            &PopupConfig::default(),
+            "ostt",
+            &["--paste".to_string()],
+        );
+
+        assert!(!args.iter().any(|arg| arg == "--class=ostt-popup"));
+        assert!(args.iter().any(|arg| arg == "--title=ostt"));
+        assert!(args.last().is_some_and(|arg| arg.contains("'--paste'")));
     }
 }

--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -1,9 +1,12 @@
 use crate::clipboard::copy_to_clipboard;
+use crate::config::PasteConfig;
 
 pub(crate) fn write_text(
     output_text: &str,
     output_file: Option<String>,
     clipboard: bool,
+    paste: bool,
+    paste_config: &PasteConfig,
     label: &str,
 ) -> anyhow::Result<()> {
     if let Some(file_path) = output_file {
@@ -17,6 +20,9 @@ pub(crate) fn write_text(
             Ok(()) => tracing::debug!("{label} copied to clipboard"),
             Err(err) => tracing::warn!("Failed to copy to clipboard: {err}"),
         }
+    } else if paste {
+        crate::paste::paste_text(output_text, paste_config)?;
+        tracing::debug!("{label} pasted to focused app");
     } else {
         println!("{output_text}");
         tracing::debug!("{label} printed to stdout");

--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -26,6 +26,7 @@ pub async fn handle_process(
     action_id: Option<String>,
     list: bool,
     clipboard: bool,
+    paste: bool,
     output_file: Option<String>,
 ) -> Result<(), anyhow::Error> {
     tracing::info!("=== ostt Process Command ===");
@@ -107,7 +108,14 @@ pub async fn handle_process(
         process::execute_action(&action, &transcription.text, &keywords).await?
     };
 
-    output::write_text(&result, output_file, clipboard, "Processed result")?;
+    output::write_text(
+        &result,
+        output_file,
+        clipboard,
+        paste,
+        &config_data.output.paste,
+        "Processed result",
+    )?;
 
     tracing::info!("=== ostt Process Command Completed ===");
     Ok(())

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -27,6 +27,7 @@ use std::sync::{
 pub async fn handle_record(
     config: &OsttConfig,
     clipboard: bool,
+    paste: bool,
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<SelectedModel>,
@@ -122,6 +123,8 @@ pub async fn handle_record(
                     &transcribed_text,
                     output_file,
                     clipboard,
+                    paste,
+                    &config.output.paste,
                 );
             };
 
@@ -137,9 +140,14 @@ pub async fn handle_record(
     };
 
     match output_text {
-        Some(output_text) => {
-            finish_recording_with_output(&mut tui, &output_text, output_file, clipboard)
-        }
+        Some(output_text) => finish_recording_with_output(
+            &mut tui,
+            &output_text,
+            output_file,
+            clipboard,
+            paste,
+            &config.output.paste,
+        ),
         None => {
             finish_recording_without_output(&mut tui)?;
             Ok(())
@@ -195,12 +203,14 @@ fn finish_recording_with_output(
     output_text: &str,
     output_file: Option<String>,
     clipboard: bool,
+    paste: bool,
+    paste_config: &crate::config::PasteConfig,
 ) -> anyhow::Result<()> {
     tui.cleanup()
         .map_err(|e| anyhow::anyhow!(e.to_string()))
         .context("failed to clean up recording UI")?;
 
-    write_record_output(output_text, output_file, clipboard)
+    write_record_output(output_text, output_file, clipboard, paste, paste_config)
         .context("failed to write recording output")?;
 
     tracing::info!("=== ostt Audio Recorder Exited Successfully ===");
@@ -325,21 +335,23 @@ fn write_record_output(
     output_text: &str,
     output_file: Option<String>,
     clipboard: bool,
+    paste: bool,
+    paste_config: &crate::config::PasteConfig,
 ) -> anyhow::Result<()> {
-    if let Some(file_path) = output_file {
-        std::fs::write(&file_path, output_text)
-            .with_context(|| format!("failed to write output file: {file_path}"))?;
-        tracing::info!("Transcription written to file: {}", file_path);
-    } else if clipboard {
-        crate::clipboard::copy_to_clipboard(output_text)
-            .context("failed to copy output to clipboard")?;
-        tracing::info!("Transcription copied to clipboard");
-    } else {
-        println!("{output_text}");
-        tracing::debug!("Transcription printed to stdout");
+    if paste {
+        crate::paste::spawn_detached_paste_helper(output_text)?;
+        tracing::debug!("Transcription sent to detached paste helper");
+        return Ok(());
     }
 
-    Ok(())
+    super::output::write_text(
+        output_text,
+        output_file,
+        clipboard,
+        paste,
+        paste_config,
+        "Transcription",
+    )
 }
 
 async fn transcribe_recording_with_animation(

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -58,7 +58,7 @@ pub async fn handle_record(
 
     // Cancel means discard the in-memory samples; only a transcribe action persists audio.
     if !run_recording_loop(&mut tui, &mut audio_recorder, actual_sample_rate, &term)
-        .context("recording loop failed")?
+        .map_err(|err| show_recording_error(&mut tui, "Recording Error", err))?
     {
         return finish_recording_without_output(&mut tui);
     }
@@ -68,7 +68,8 @@ pub async fn handle_record(
 
     let output_format = resolve_recording_output_format(config, model_override.as_ref());
     let Some(filepath) = storage::save_recording(&mut audio_recorder, &output_format)
-        .context("failed to save recording")?
+        .context("failed to save recording")
+        .map_err(|err| show_recording_error(&mut tui, "Recording Error", err))?
     else {
         return finish_recording_without_output(&mut tui);
     };
@@ -78,11 +79,11 @@ pub async fn handle_record(
 
     let transcription_context =
         crate::transcription::build_context(config, model_override, param_overrides)
-            .context("failed to build transcription context")?;
+            .context("failed to build transcription context")
+            .map_err(|err| show_recording_error(&mut tui, "Transcription Error", err))?;
     let model_id = transcription_context.selected_model.model_id.clone();
     let filepath_str = filepath.to_string_lossy().to_string();
 
-    let mut transcription_error = None;
     let maybe_transcribed_text = match transcribe_recording_with_animation(
         &mut tui,
         transcription_context.config,
@@ -98,7 +99,10 @@ pub async fn handle_record(
         }
         Err(e) => {
             tracing::warn!("Transcription failed: {}", e);
-            transcription_error = Some(e.to_string());
+            let message = format!("Transcription failed: {e}");
+            if let Err(display_err) = tui.show_error("Transcription Error", &message) {
+                tracing::warn!("Failed to show transcription error in TUI: {display_err}");
+            }
             None
         }
     };
@@ -110,7 +114,8 @@ pub async fn handle_record(
                 process::select_requested_action(&config.process, process.as_deref(), |actions| {
                     pick_action_id_with_recording_tui(&mut tui, actions)
                 })
-                .context("failed to select process action")?
+                .context("failed to select process action")
+                .map_err(|err| show_recording_error(&mut tui, "Processing Error", err))?
             else {
                 return finish_recording_with_output(
                     &mut tui,
@@ -123,7 +128,8 @@ pub async fn handle_record(
             Some(
                 run_process_action_with_animation(&mut tui, action, transcribed_text)
                     .await
-                    .context("failed to process transcription")?,
+                    .context("failed to process transcription")
+                    .map_err(|err| show_recording_error(&mut tui, "Processing Error", err))?,
             )
         }
         Some(transcribed_text) => Some(transcribed_text),
@@ -136,12 +142,21 @@ pub async fn handle_record(
         }
         None => {
             finish_recording_without_output(&mut tui)?;
-            if let Some(error) = transcription_error {
-                eprintln!("Warning: Transcription failed: {error}");
-            }
             Ok(())
         }
     }
+}
+
+fn show_recording_error(
+    tui: &mut RecordingTui,
+    title: &str,
+    error: anyhow::Error,
+) -> anyhow::Error {
+    let message = error.to_string();
+    if let Err(display_err) = tui.show_error(title, &message) {
+        tracing::warn!("Failed to show recording error in TUI: {display_err}");
+    }
+    error
 }
 
 fn resolve_recording_output_format(

--- a/src/commands/retry.rs
+++ b/src/commands/retry.rs
@@ -19,6 +19,7 @@ pub async fn handle_retry(
     config_data: &config::OsttConfig,
     recording_index: Option<usize>,
     clipboard: bool,
+    paste: bool,
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<config::SelectedModel>,
@@ -70,7 +71,14 @@ pub async fn handle_retry(
                 process.as_deref(),
             )
             .await?;
-            output::write_text(&output_text, output_file, clipboard, "Output text")?;
+            output::write_text(
+                &output_text,
+                output_file,
+                clipboard,
+                paste,
+                &config_data.output.paste,
+                "Output text",
+            )?;
 
             Ok(())
         }

--- a/src/commands/transcribe.rs
+++ b/src/commands/transcribe.rs
@@ -22,6 +22,7 @@ pub async fn handle_transcribe(
     config_data: &config::OsttConfig,
     file: PathBuf,
     clipboard: bool,
+    paste: bool,
     output_file: Option<String>,
     process: Option<String>,
     model_override: Option<config::SelectedModel>,
@@ -58,7 +59,14 @@ pub async fn handle_transcribe(
         process.as_deref(),
     )
     .await?;
-    output::write_text(&output_text, output_file, clipboard, "Output text")?;
+    output::write_text(
+        &output_text,
+        output_file,
+        clipboard,
+        paste,
+        &config_data.output.paste,
+        "Output text",
+    )?;
 
     Ok(())
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -188,6 +188,47 @@ pub struct TextConfig {
     pub replace: IndexMap<String, String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PasteConfig {
+    pub paste_key: String,
+    pub restore_clipboard: bool,
+    pub restore_delay_ms: u64,
+    pub post_popup_delay_ms: u64,
+}
+
+impl Default for PasteConfig {
+    fn default() -> Self {
+        Self {
+            paste_key: default_paste_key(),
+            restore_clipboard: true,
+            restore_delay_ms: 750,
+            post_popup_delay_ms: 1000,
+        }
+    }
+}
+
+fn default_paste_key() -> String {
+    if cfg!(target_os = "macos") {
+        "cmd+v".to_string()
+    } else if is_omarchy() {
+        "shift+insert".to_string()
+    } else {
+        "ctrl+v".to_string()
+    }
+}
+
+fn is_omarchy() -> bool {
+    std::env::var_os("HOME")
+        .is_some_and(|home| PathBuf::from(home).join(".local/share/omarchy").exists())
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OutputConfig {
+    pub paste: PasteConfig,
+}
+
 /// Popup window configuration for the `launch` subcommand.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PopupConfig {
@@ -565,7 +606,14 @@ pub struct TranscriptionSelectionConfig {
     pub model: Option<String>,
 }
 
-const FIXED_TOP_LEVEL_SECTIONS: &[&str] = &["audio", "transcription", "text", "process", "popup"];
+const FIXED_TOP_LEVEL_SECTIONS: &[&str] = &[
+    "audio",
+    "transcription",
+    "text",
+    "output",
+    "process",
+    "popup",
+];
 const DEPRECATED_TOP_LEVEL_SECTIONS: &[&str] = &["providers", "model_options"];
 
 /// Complete application configuration.
@@ -576,6 +624,7 @@ pub struct OsttConfig {
     pub transcription: TranscriptionSelectionConfig,
     pub provider_configs: ProviderConfigs,
     pub text: TextConfig,
+    pub output: OutputConfig,
     pub process: ProcessConfig,
     pub popup: PopupConfig,
 }
@@ -636,6 +685,7 @@ impl OsttConfig {
             transcription: TranscriptionSelectionConfig::default(),
             provider_configs: ProviderConfigs::default(),
             text: TextConfig::default(),
+            output: OutputConfig::default(),
             process: ProcessConfig::default(),
             popup: PopupConfig::default(),
         }
@@ -654,6 +704,7 @@ fn parse_config_table(table: &mut toml::Table) -> anyhow::Result<OsttConfig> {
     let transcription =
         take_optional_section::<TranscriptionSelectionConfig>(table, "transcription")?;
     let text = take_optional_section::<TextConfig>(table, "text")?;
+    let output = take_optional_section::<OutputConfig>(table, "output")?;
     let process = take_optional_section::<ProcessConfig>(table, "process")?;
     let popup = take_optional_section::<PopupConfig>(table, "popup")?;
 
@@ -665,7 +716,7 @@ fn parse_config_table(table: &mut toml::Table) -> anyhow::Result<OsttConfig> {
         }
         if crate::transcription::TranscriptionProvider::from_id(&provider_id).is_none() {
             anyhow::bail!(
-                "Unknown top-level config section '{}'. Expected one of: audio, transcription, text, process, popup, {}.",
+                "Unknown top-level config section '{}'. Expected one of: audio, transcription, text, output, process, popup, {}.",
                 provider_id,
                 crate::transcription::TranscriptionProvider::supported_ids().join(", ")
             );
@@ -685,6 +736,7 @@ fn parse_config_table(table: &mut toml::Table) -> anyhow::Result<OsttConfig> {
         transcription,
         provider_configs,
         text,
+        output,
         process,
         popup,
     };
@@ -869,6 +921,9 @@ fn config_to_table(config: &OsttConfig) -> anyhow::Result<toml::Table> {
     if !config.text.replace.is_empty() {
         table.insert("text".to_string(), toml::Value::try_from(&config.text)?);
     }
+    if config.output != OutputConfig::default() {
+        table.insert("output".to_string(), toml::Value::try_from(&config.output)?);
+    }
     if !config.process.actions.is_empty() {
         table.insert(
             "process".to_string(),
@@ -950,6 +1005,36 @@ pub fn validate_config(config: &OsttConfig) -> anyhow::Result<()> {
     for source in config.text.replace.keys() {
         if source.trim().is_empty() {
             anyhow::bail!("Text replace source must not be empty.");
+        }
+    }
+
+    validate_paste_key(&config.output.paste.paste_key)?;
+
+    Ok(())
+}
+
+fn validate_paste_key(paste_key: &str) -> anyhow::Result<()> {
+    let parts: Vec<_> = paste_key
+        .split('+')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect();
+    if parts.len() < 2 {
+        anyhow::bail!("[output.paste].paste_key must be a key combination like 'ctrl+v'.");
+    }
+
+    let key = parts[parts.len() - 1].to_lowercase();
+    if key.len() != 1 && key != "insert" {
+        anyhow::bail!("[output.paste].paste_key must end with a single key or 'insert'.");
+    }
+
+    for modifier in &parts[..parts.len() - 1] {
+        match modifier.to_lowercase().as_str() {
+            "ctrl" | "shift" | "alt" | "cmd" | "super" => {}
+            _ => anyhow::bail!(
+                "Unsupported paste_key modifier '{}'. Supported modifiers: ctrl, shift, alt, cmd, super.",
+                modifier
+            ),
         }
     }
 
@@ -1409,6 +1494,57 @@ mod tests {
         let err = parse_ostt_config(toml_str).unwrap_err().to_string();
 
         assert!(err.contains("Text replace source must not be empty"));
+    }
+
+    #[test]
+    fn missing_output_section_defaults_to_paste_defaults() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+
+        assert!(!config.output.paste.paste_key.is_empty());
+        assert!(config.output.paste.restore_clipboard);
+        assert_eq!(config.output.paste.restore_delay_ms, 750);
+        assert_eq!(config.output.paste.post_popup_delay_ms, 1000);
+    }
+
+    #[test]
+    fn output_paste_preserves_configured_values() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [output.paste]
+            paste_key = "super+v"
+            restore_clipboard = false
+            restore_delay_ms = 300
+            post_popup_delay_ms = 100
+        "#;
+
+        let config = parse_ostt_config(toml_str).unwrap();
+
+        assert_eq!(config.output.paste.paste_key, "super+v");
+        assert!(!config.output.paste.restore_clipboard);
+        assert_eq!(config.output.paste.restore_delay_ms, 300);
+        assert_eq!(config.output.paste.post_popup_delay_ms, 100);
+    }
+
+    #[test]
+    fn invalid_output_paste_key_fails_validation() {
+        let toml_str = r#"
+            [audio]
+            device = "default"
+
+            [output.paste]
+            paste_key = "hyper+v"
+        "#;
+
+        let err = parse_ostt_config(toml_str).unwrap_err().to_string();
+
+        assert!(err.contains("Unsupported paste_key modifier"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,9 +14,9 @@ pub use file::{
     ProcessConfig,
 };
 pub use file::{
-    AudioConfig, ModelOptionValue, OsttConfig, ParamsConfig, PopupConfig, ProviderConfig,
-    ProviderConfigs, ProviderModelConfig, ProviderSettings, TextConfig,
-    TranscriptionSelectionConfig, VisualizationType,
+    AudioConfig, ModelOptionValue, OsttConfig, OutputConfig, ParamsConfig, PasteConfig,
+    PopupConfig, ProviderConfig, ProviderConfigs, ProviderModelConfig, ProviderSettings,
+    TextConfig, TranscriptionSelectionConfig, VisualizationType,
 };
 pub use secrets::{
     clear_api_key, clear_selected_model, get_api_key, get_authorized_providers, get_selected_model,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod history;
 pub mod keywords;
 pub mod logging;
 pub mod model;
+pub(crate) mod paste;
 pub mod process;
 pub mod recording;
 pub mod setup;

--- a/src/model/local_model_view/local_model_list_view.rs
+++ b/src/model/local_model_view/local_model_list_view.rs
@@ -50,7 +50,14 @@ impl LocalModelListView {
 fn section_header(label: impl Into<String>) -> ListItem<'static> {
     ListItem::new(Line::from(Span::styled(
         format!(" {} ", label.into()),
-        Style::default().fg(Color::Black).bg(Color::Cyan),
+        Style::default().fg(Color::Black).bg(Color::Green),
+    )))
+}
+
+fn group_header(label: impl Into<String>) -> ListItem<'static> {
+    ListItem::new(Line::from(Span::styled(
+        format!(" {} ", label.into()),
+        Style::default().fg(Color::Black).bg(Color::Magenta),
     )))
 }
 
@@ -59,14 +66,25 @@ fn push_grouped_model_items(
     entries: Vec<&LocalModelEntry>,
     selected_id: Option<&str>,
 ) {
+    let mut current_section: Option<&str> = None;
     let mut current_group: Option<&str> = None;
     for entry in entries {
-        let group = entry.group_id.as_deref().unwrap_or("Custom models");
+        let section = section_label(entry);
+        let group = group_label(entry);
+        if current_section != Some(section) {
+            if current_section.is_some() {
+                items.push(ListItem::new(Line::from("")));
+            }
+            items.push(section_header(section.to_string()));
+            items.push(ListItem::new(Line::from("")));
+            current_section = Some(section);
+            current_group = None;
+        }
         if current_group != Some(group) {
             if current_group.is_some() {
                 items.push(ListItem::new(Line::from("")));
             }
-            items.push(section_header(group.to_string()));
+            items.push(group_header(group.to_string()));
             items.push(ListItem::new(Line::from("")));
             current_group = Some(group);
         }
@@ -152,9 +170,20 @@ pub(super) fn grouped_display_index(
     start_index: usize,
 ) -> Option<usize> {
     let mut index = start_index;
+    let mut current_section: Option<&str> = None;
     let mut current_group: Option<&str> = None;
     for entry in entries {
-        let group = entry.group_id.as_deref().unwrap_or("Custom models");
+        let section = section_label(entry);
+        let group = group_label(entry);
+        if current_section != Some(section) {
+            if current_section.is_some() {
+                index += 1;
+            }
+            index += 1;
+            index += 1;
+            current_section = Some(section);
+            current_group = None;
+        }
         if current_group != Some(group) {
             if current_group.is_some() {
                 index += 1;
@@ -172,4 +201,21 @@ pub(super) fn grouped_display_index(
 
 fn model_key(entry: &LocalModelEntry) -> String {
     format!("{}/{}", entry.provider_id, entry.id)
+}
+
+fn section_label(entry: &LocalModelEntry) -> &'static str {
+    if entry.group_id.as_deref() == Some("Custom models") {
+        "Custom models"
+    } else if entry.provider_id == "whisper" {
+        "Local models"
+    } else {
+        "Cloud models"
+    }
+}
+
+fn group_label(entry: &LocalModelEntry) -> &str {
+    entry
+        .group_id
+        .as_deref()
+        .unwrap_or_else(|| section_label(entry))
 }

--- a/src/model/local_model_view/local_model_list_view.rs
+++ b/src/model/local_model_view/local_model_list_view.rs
@@ -84,8 +84,10 @@ fn push_grouped_model_items(
             if current_group.is_some() {
                 items.push(ListItem::new(Line::from("")));
             }
-            items.push(group_header(group.to_string()));
-            items.push(ListItem::new(Line::from("")));
+            if group != section {
+                items.push(group_header(group.to_string()));
+                items.push(ListItem::new(Line::from("")));
+            }
             current_group = Some(group);
         }
         let is_selected = selected_id.as_deref() == Some(model_key(entry).as_str());
@@ -188,7 +190,9 @@ pub(super) fn grouped_display_index(
             if current_group.is_some() {
                 index += 1;
             }
-            index += 2;
+            if group != section {
+                index += 2;
+            }
             current_group = Some(group);
         }
         if model_key(entry) == selected_entry_id {

--- a/src/model/local_model_view/mod.rs
+++ b/src/model/local_model_view/mod.rs
@@ -289,8 +289,12 @@ fn build_cloud_model_entries(
         .iter()
         .filter(|provider| provider.requires_auth())
         .filter(|provider| authorized.contains(provider.id()))
-        .flat_map(|provider| transcription::models_for_provider(provider))
-        .map(|model| LocalModelEntry {
+        .flat_map(|provider| {
+            transcription::models_for_provider(provider)
+                .into_iter()
+                .map(move |model| (provider.name(), model))
+        })
+        .map(|(provider_name, model)| LocalModelEntry {
             id: model.model_id.to_string(),
             provider_id: model.provider_id.to_string(),
             name: model.display_name.to_string(),
@@ -313,7 +317,7 @@ fn build_cloud_model_entries(
             recommended_hardware: None,
             category: None,
             sha256: None,
-            group_id: Some("Cloud models".to_string()),
+            group_id: Some(provider_name.to_string()),
         })
         .collect()
 }
@@ -362,7 +366,10 @@ fn local_model_entry_from_registry_entry(
         recommended_hardware: entry.recommended_hardware.clone(),
         category: entry.category.clone(),
         sha256: entry.sha256.clone(),
-        group_id: Some("Local models".to_string()),
+        group_id: entry
+            .group_id
+            .clone()
+            .or_else(|| Some("Local models".to_string())),
     }
 }
 
@@ -939,7 +946,10 @@ mod tests {
     #[test]
     fn build_model_entries_orders_custom_before_local_entries() {
         with_isolated_models_dir(|_| {
-            let registry = vec![registry_entry("turbo")];
+            let registry = vec![RegistryEntry {
+                group_id: Some("nbailab".to_string()),
+                ..registry_entry("turbo")
+            }];
             let state = LocalModelState {
                 version: 1,
                 custom_models: vec![RegistryEntry {
@@ -956,7 +966,7 @@ mod tests {
             assert_eq!(entries[0].id, "custom");
             assert_eq!(entries[0].group_id.as_deref(), Some("Custom models"));
             assert_eq!(entries[1].id, "turbo");
-            assert_eq!(entries[1].group_id.as_deref(), Some("Local models"));
+            assert_eq!(entries[1].group_id.as_deref(), Some("nbailab"));
             assert!(entries.iter().any(|entry| {
                 entry.id == "turbo" && entry.is_available_in_registry && !entry.is_downloaded
             }));
@@ -964,6 +974,28 @@ mod tests {
                 entry.id == "custom"
                     && !entry.is_available_in_registry
                     && entry.category.as_deref() == Some("custom")
+            }));
+        });
+    }
+
+    #[test]
+    fn build_model_entries_groups_cloud_models_by_provider_name() {
+        with_isolated_models_dir(|_| {
+            let config = config::OsttConfig::default();
+            let entries = build_model_entries(
+                &config,
+                &["openai".to_string(), "deepgram".to_string()],
+                &LocalModelState::default(),
+                &[],
+                None,
+                None,
+            );
+
+            assert!(entries.iter().any(|entry| {
+                entry.provider_id == "openai" && entry.group_id.as_deref() == Some("OpenAI")
+            }));
+            assert!(entries.iter().any(|entry| {
+                entry.provider_id == "deepgram" && entry.group_id.as_deref() == Some("Deepgram")
             }));
         });
     }
@@ -1126,6 +1158,6 @@ mod tests {
             },
         ];
         let idx = grouped_display_index(entries.iter().collect(), "whisper/tiny", 0);
-        assert_eq!(idx, Some(2));
+        assert_eq!(idx, Some(4));
     }
 }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -90,7 +90,7 @@ pub(crate) fn spawn_detached_paste_helper(text: &str) -> anyhow::Result<()> {
     let exe = std::env::current_exe().context("failed to resolve ostt executable path")?;
     let mut command = Command::new(exe);
     command
-        .arg("__paste")
+        .arg("paste-helper")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null());

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -4,13 +4,16 @@ use anyhow::Context;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+#[cfg(not(target_os = "macos"))]
 const POPUP_TITLE: &str = "ostt";
 
 pub(crate) fn wait_for_focus_after_popup(config: &PasteConfig) {
     #[cfg(not(target_os = "macos"))]
     {
+        use std::time::Instant;
+
         if std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok() {
             let deadline = Instant::now() + Duration::from_millis(config.post_popup_delay_ms);
             while Instant::now() < deadline {
@@ -60,6 +63,7 @@ pub(crate) fn paste_text(text: &str, config: &PasteConfig) -> anyhow::Result<()>
     set_clipboard(text).context("failed to copy text to clipboard for paste")?;
     tracing::debug!("Paste mode: copied {} bytes to clipboard", text.len());
 
+    #[cfg(not(target_os = "macos"))]
     log_active_window("before paste key");
     if let Err(err) = send_paste_key(&config.paste_key) {
         tracing::warn!("Failed to send paste key '{}': {err}", config.paste_key);
@@ -126,17 +130,15 @@ pub(crate) fn handle_paste_helper(config: &crate::config::OsttConfig) -> anyhow:
     paste_text(&text, &config.output.paste)
 }
 
+#[cfg(not(target_os = "macos"))]
 fn log_active_window(label: &str) {
-    #[cfg(not(target_os = "macos"))]
+    if let Ok(output) = Command::new("hyprctl")
+        .args(["activewindow", "-j"])
+        .output()
     {
-        if let Ok(output) = Command::new("hyprctl")
-            .args(["activewindow", "-j"])
-            .output()
-        {
-            if output.status.success() {
-                let text = String::from_utf8_lossy(&output.stdout);
-                tracing::debug!("Paste mode: active window {label}: {}", text.trim());
-            }
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            tracing::debug!("Paste mode: active window {label}: {}", text.trim());
         }
     }
 }
@@ -296,6 +298,8 @@ fn xdotool_modifier(modifier: &str) -> anyhow::Result<&'static str> {
 
 fn run_status(command: &mut Command, name: &str) -> anyhow::Result<()> {
     let status = command
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()
         .with_context(|| format!("Failed to run {name}"))?;
     if !status.success() {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -1,0 +1,305 @@
+use crate::clipboard::{read_clipboard, set_clipboard};
+use crate::config::PasteConfig;
+use anyhow::Context;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const POPUP_TITLE: &str = "ostt";
+
+pub(crate) fn wait_for_focus_after_popup(config: &PasteConfig) {
+    #[cfg(not(target_os = "macos"))]
+    {
+        if std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok() {
+            let deadline = Instant::now() + Duration::from_millis(config.post_popup_delay_ms);
+            while Instant::now() < deadline {
+                match active_hyprland_window_title() {
+                    Some(title) if title == POPUP_TITLE => {
+                        thread::sleep(Duration::from_millis(25));
+                    }
+                    Some(title) => {
+                        tracing::debug!("Paste mode: focus returned to window title '{title}'");
+                        return;
+                    }
+                    None => break,
+                }
+            }
+
+            tracing::debug!(
+                "Paste mode: focus settle timeout reached after {}ms",
+                config.post_popup_delay_ms
+            );
+            return;
+        }
+    }
+
+    thread::sleep(Duration::from_millis(config.post_popup_delay_ms));
+}
+
+pub(crate) fn paste_text(text: &str, config: &PasteConfig) -> anyhow::Result<()> {
+    tracing::debug!(
+        "Paste mode: paste_key='{}', restore_clipboard={}, restore_delay_ms={}",
+        config.paste_key,
+        config.restore_clipboard,
+        config.restore_delay_ms
+    );
+
+    let previous_clipboard = if config.restore_clipboard {
+        match read_clipboard() {
+            Ok(value) => Some(value),
+            Err(err) => {
+                tracing::warn!("Failed to read clipboard before paste: {err}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    set_clipboard(text).context("failed to copy text to clipboard for paste")?;
+    tracing::debug!("Paste mode: copied {} bytes to clipboard", text.len());
+
+    log_active_window("before paste key");
+    if let Err(err) = send_paste_key(&config.paste_key) {
+        tracing::warn!("Failed to send paste key '{}': {err}", config.paste_key);
+        eprintln!(
+            "Warning: Failed to send paste key '{}'. Text was copied to the clipboard.",
+            config.paste_key
+        );
+        return Ok(());
+    }
+
+    thread::sleep(Duration::from_millis(config.restore_delay_ms));
+
+    if let Some(previous_clipboard) = previous_clipboard {
+        if let Err(err) = set_clipboard(&previous_clipboard) {
+            tracing::warn!("Failed to restore clipboard after paste: {err}");
+            eprintln!("Warning: Failed to restore previous clipboard contents after paste.");
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn spawn_detached_paste_helper(text: &str) -> anyhow::Result<()> {
+    let exe = std::env::current_exe().context("failed to resolve ostt executable path")?;
+    let mut command = Command::new(exe);
+    command
+        .arg("__paste")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    detach_from_terminal_process_group(&mut command);
+
+    let mut child = command.spawn().context("failed to spawn paste helper")?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("failed to open paste helper stdin"))?;
+    stdin
+        .write_all(text.as_bytes())
+        .context("failed to write text to paste helper")?;
+    drop(stdin);
+    drop(child);
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn detach_from_terminal_process_group(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    command.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn detach_from_terminal_process_group(_command: &mut Command) {}
+
+pub(crate) fn handle_paste_helper(config: &crate::config::OsttConfig) -> anyhow::Result<()> {
+    let mut text = String::new();
+    std::io::stdin()
+        .read_to_string(&mut text)
+        .context("failed to read paste helper input")?;
+    wait_for_focus_after_popup(&config.output.paste);
+    paste_text(&text, &config.output.paste)
+}
+
+fn log_active_window(label: &str) {
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Ok(output) = Command::new("hyprctl")
+            .args(["activewindow", "-j"])
+            .output()
+        {
+            if output.status.success() {
+                let text = String::from_utf8_lossy(&output.stdout);
+                tracing::debug!("Paste mode: active window {label}: {}", text.trim());
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn active_hyprland_window_title() -> Option<String> {
+    let output = Command::new("hyprctl")
+        .args(["activewindow", "-j"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    value
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn send_paste_key(paste_key: &str) -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return send_macos_key(paste_key);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        send_linux_key(paste_key)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn send_macos_key(paste_key: &str) -> anyhow::Result<()> {
+    let (modifiers, key) = parse_paste_key(paste_key)?;
+    let mut using_parts = Vec::new();
+    for modifier in modifiers {
+        using_parts.push(match modifier.as_str() {
+            "cmd" => "command down",
+            "ctrl" => "control down",
+            "shift" => "shift down",
+            "alt" => "option down",
+            "super" => "command down",
+            _ => anyhow::bail!("Unsupported macOS paste modifier '{modifier}'"),
+        });
+    }
+
+    let script = if using_parts.is_empty() {
+        format!("tell application \"System Events\" to keystroke \"{key}\"")
+    } else {
+        format!(
+            "tell application \"System Events\" to keystroke \"{key}\" using {{{}}}",
+            using_parts.join(", ")
+        )
+    };
+
+    run_status(Command::new("osascript").args(["-e", &script]), "osascript")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn send_linux_key(paste_key: &str) -> anyhow::Result<()> {
+    if std::env::var("WAYLAND_DISPLAY").is_ok() {
+        if let Ok(()) = send_wtype_key(paste_key) {
+            return Ok(());
+        }
+    }
+
+    send_xdotool_key(paste_key)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn send_wtype_key(paste_key: &str) -> anyhow::Result<()> {
+    let (modifiers, key) = parse_paste_key(paste_key)?;
+    let key = linux_key_name(&key);
+    let mut args = Vec::new();
+    for modifier in &modifiers {
+        args.push("-M".to_string());
+        args.push(wtype_modifier(modifier)?.to_string());
+    }
+    args.push("-P".to_string());
+    args.push(key.clone());
+    args.push("-p".to_string());
+    args.push(key);
+    for modifier in modifiers.iter().rev() {
+        args.push("-m".to_string());
+        args.push(wtype_modifier(modifier)?.to_string());
+    }
+
+    tracing::debug!("Paste mode: running wtype {:?}", args);
+    run_status(Command::new("wtype").args(args), "wtype")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn send_xdotool_key(paste_key: &str) -> anyhow::Result<()> {
+    let (modifiers, key) = parse_paste_key(paste_key)?;
+    let mut parts: Vec<String> = modifiers
+        .iter()
+        .map(|modifier| xdotool_modifier(modifier).map(str::to_string))
+        .collect::<anyhow::Result<_>>()?;
+    parts.push(linux_key_name(&key));
+    tracing::debug!("Paste mode: running xdotool key {}", parts.join("+"));
+    run_status(
+        Command::new("xdotool").args(["key", &parts.join("+")]),
+        "xdotool",
+    )
+}
+
+fn parse_paste_key(paste_key: &str) -> anyhow::Result<(Vec<String>, String)> {
+    let parts: Vec<_> = paste_key
+        .split('+')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::to_lowercase)
+        .collect();
+    if parts.len() < 2 {
+        anyhow::bail!("paste_key must be a key combination like 'ctrl+v'");
+    }
+    Ok((
+        parts[..parts.len() - 1].to_vec(),
+        parts[parts.len() - 1].clone(),
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn linux_key_name(key: &str) -> String {
+    if key == "insert" {
+        "Insert".to_string()
+    } else {
+        key.to_string()
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn wtype_modifier(modifier: &str) -> anyhow::Result<&'static str> {
+    match modifier {
+        "ctrl" => Ok("ctrl"),
+        "shift" => Ok("shift"),
+        "alt" => Ok("alt"),
+        "super" => Ok("logo"),
+        "cmd" => Ok("logo"),
+        _ => anyhow::bail!("Unsupported paste_key modifier '{modifier}'"),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn xdotool_modifier(modifier: &str) -> anyhow::Result<&'static str> {
+    match modifier {
+        "ctrl" => Ok("ctrl"),
+        "shift" => Ok("shift"),
+        "alt" => Ok("alt"),
+        "super" => Ok("Super_L"),
+        "cmd" => Ok("Super_L"),
+        _ => anyhow::bail!("Unsupported paste_key modifier '{modifier}'"),
+    }
+}
+
+fn run_status(command: &mut Command, name: &str) -> anyhow::Result<()> {
+    let status = command
+        .status()
+        .with_context(|| format!("Failed to run {name}"))?;
+    if !status.success() {
+        anyhow::bail!("{name} failed with status {status}");
+    }
+    Ok(())
+}

--- a/src/recording/tui.rs
+++ b/src/recording/tui.rs
@@ -464,11 +464,24 @@ impl RecordingTui {
                     height: area.height.saturating_sub(area.height / 2),
                 };
 
-                let text = format!("{title}\n\n{message}\n\nPress any key to close.");
+                let title_line = ratatui::text::Line::from(ratatui::text::Span::styled(
+                    format!(" {title} "),
+                    Style::default().fg(Color::Black).bg(Color::Red),
+                ))
+                .alignment(Alignment::Center);
+
+                let text = ratatui::text::Text::from(vec![
+                    title_line,
+                    ratatui::text::Line::raw(""),
+                    ratatui::text::Line::raw(message),
+                    ratatui::text::Line::raw(""),
+                    ratatui::text::Line::raw("Press any key to close."),
+                ]);
+
                 let paragraph = Paragraph::new(text)
                     .alignment(Alignment::Center)
                     .wrap(Wrap { trim: true })
-                    .style(Style::default().fg(Color::Black).bg(Color::Red));
+                    .style(Style::reset().fg(Color::White));
 
                 frame.render_widget(paragraph, padded_area);
             })?;

--- a/src/recording/tui.rs
+++ b/src/recording/tui.rs
@@ -11,7 +11,7 @@ use crossterm::{
 use ratatui::{
     prelude::*,
     style::{Color, Style},
-    widgets::{ListState, Sparkline},
+    widgets::{ListState, Paragraph, Sparkline, Wrap},
 };
 use std::error::Error;
 use std::io::{stdout, Stdout};
@@ -447,6 +447,40 @@ impl RecordingTui {
         }
 
         Ok(None)
+    }
+
+    /// Displays an error in the active recording UI until the user presses a key.
+    pub fn show_error(&mut self, title: &str, message: &str) -> Result<(), Box<dyn Error>> {
+        loop {
+            self.terminal.draw(|frame| {
+                let area = frame.area();
+                let background = ratatui::widgets::Block::default().style(Style::reset());
+                frame.render_widget(background, area);
+
+                let padded_area = Rect {
+                    x: area.x.saturating_add(area.width / 10),
+                    y: area.y.saturating_add(area.height / 4),
+                    width: area.width.saturating_sub((area.width / 10) * 2),
+                    height: area.height.saturating_sub(area.height / 2),
+                };
+
+                let text = format!("{title}\n\n{message}\n\nPress any key to close.");
+                let paragraph = Paragraph::new(text)
+                    .alignment(Alignment::Center)
+                    .wrap(Wrap { trim: true })
+                    .style(Style::default().fg(Color::Black).bg(Color::Red));
+
+                frame.render_widget(paragraph, padded_area);
+            })?;
+
+            if event::poll(std::time::Duration::from_millis(100))? {
+                if let Event::Key(_) = event::read()? {
+                    break;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Cleans up terminal state and exits alternate screen mode.


### PR DESCRIPTION
## Summary
- Add explicit `--paste` output mode for record, launch, transcribe, retry, and process flows.
- Add `[output.paste]` config with environment-aware defaults: `cmd+v` on macOS, `shift+insert` on Omarchy, and `ctrl+v` on other Linux desktops.
- Implement clipboard-backed paste with clipboard restore, focus settling for popup launch, and a detached paste helper so the popup can close before pasting.
- Restore in-TUI error display for record-time failures and refine the error screen styling.
- Stop passing Ghostty's invalid `--class` arg and suppress popup terminal stdout/stderr in launch.

## Notes
- Paste mode is mutually exclusive with clipboard/file output.
- Linux paste shortcuts are not universal, so `paste_key` remains configurable.
- macOS paste may require Accessibility permission for the terminal app running OSTT.

## Verification
- `cargo fmt --check`
- `cargo test`
- Manual smoke test on Omarchy/Hyprland with `cargo run -- launch --paste`