### PR TITLE
Fix GPU version strings, release filenames, backend logging, ydotool paste, xclip noise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,16 +255,12 @@ jobs:
         run: cargo deb --no-build
       - name: Build .rpm package
         run: cargo generate-rpm
-      - name: Create stable-name copies
-        run: |
-          cp target/debian/*.deb target/debian/ostt_latest_${{ matrix.deb_arch }}.deb
-          cp target/generate-rpm/*.rpm target/generate-rpm/ostt-latest.${{ matrix.rpm_arch }}.rpm
       - name: Create package checksums
         run: |
           cd target/debian
-          sha256sum ostt_latest_${{ matrix.deb_arch }}.deb > ostt_latest_${{ matrix.deb_arch }}.deb.sha256
+          sha256sum *.deb > "$(ls *.deb).sha256"
           cd ../generate-rpm
-          sha256sum ostt-latest.${{ matrix.rpm_arch }}.rpm > ostt-latest.${{ matrix.rpm_arch }}.rpm.sha256
+          sha256sum *.rpm > "$(ls *.rpm).sha256"
       - name: "Upload Linux packages"
         uses: actions/upload-artifact@v4
         with:
@@ -330,37 +326,32 @@ jobs:
         run: cargo deb --no-build --variant cuda
       - name: Build .rpm package (cuda variant)
         run: cargo generate-rpm -s 'name = "ostt-cuda"'
-      - name: Create stable-name copies and archive
+      - name: Create versioned archive and checksums
         run: |
-          # .deb
-          cp target/debian/ostt-cuda_*.deb target/debian/ostt-cuda_latest_amd64.deb
-          # .rpm
-          cp target/generate-rpm/ostt-cuda-*.rpm target/generate-rpm/ostt-cuda-latest.x86_64.rpm
-          # tar.gz archive (named with -cuda suffix for the install script)
+          VERSION=${GITHUB_REF_NAME#v}
+          # tar.gz archive with version in name
           mkdir -p /tmp/ostt-cuda-archive
           cp target/dist/ostt /tmp/ostt-cuda-archive/ostt
-          tar -czf ostt-x86_64-unknown-linux-gnu-cuda.tar.gz \
+          tar -czf "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz" \
             -C /tmp/ostt-cuda-archive ostt
-      - name: Create checksums
-        run: |
+          sha256sum "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz" \
+            > "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz.sha256"
+          # .deb and .rpm checksums (already versioned by cargo-deb / cargo-generate-rpm)
           cd target/debian
-          sha256sum ostt-cuda_latest_amd64.deb > ostt-cuda_latest_amd64.deb.sha256
+          sha256sum ostt-cuda_*.deb > "$(ls ostt-cuda_*.deb).sha256"
           cd ../generate-rpm
-          sha256sum ostt-cuda-latest.x86_64.rpm > ostt-cuda-latest.x86_64.rpm.sha256
-          cd ../..
-          sha256sum ostt-x86_64-unknown-linux-gnu-cuda.tar.gz \
-            > ostt-x86_64-unknown-linux-gnu-cuda.tar.gz.sha256
+          sha256sum ostt-cuda-*.rpm > "$(ls ostt-cuda-*.rpm).sha256"
       - name: Upload CUDA artifacts
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-build-linux-cuda-amd64
           path: |
-            ostt-x86_64-unknown-linux-gnu-cuda.tar.gz
-            ostt-x86_64-unknown-linux-gnu-cuda.tar.gz.sha256
-            target/debian/ostt-cuda_latest_amd64.deb
-            target/debian/ostt-cuda_latest_amd64.deb.sha256
-            target/generate-rpm/ostt-cuda-latest.x86_64.rpm
-            target/generate-rpm/ostt-cuda-latest.x86_64.rpm.sha256
+            ostt-*-x86_64-unknown-linux-gnu-cuda.tar.gz
+            ostt-*-x86_64-unknown-linux-gnu-cuda.tar.gz.sha256
+            target/debian/ostt-cuda_*.deb
+            target/debian/ostt-cuda_*.deb.sha256
+            target/generate-rpm/ostt-cuda-*.rpm
+            target/generate-rpm/ostt-cuda-*.rpm.sha256
 
   # Build Vulkan-accelerated Linux x86_64 binary and packages.
   # Produces ostt-x86_64-unknown-linux-gnu-vulkan.tar.gz, ostt-vulkan .deb and .rpm.
@@ -402,37 +393,32 @@ jobs:
         run: cargo deb --no-build --variant vulkan
       - name: Build .rpm package (vulkan variant)
         run: cargo generate-rpm -s 'name = "ostt-vulkan"'
-      - name: Create stable-name copies and archive
+      - name: Create versioned archive and checksums
         run: |
-          # .deb
-          cp target/debian/ostt-vulkan_*.deb target/debian/ostt-vulkan_latest_amd64.deb
-          # .rpm
-          cp target/generate-rpm/ostt-vulkan-*.rpm target/generate-rpm/ostt-vulkan-latest.x86_64.rpm
-          # tar.gz archive (named with -vulkan suffix for the install script)
+          VERSION=${GITHUB_REF_NAME#v}
+          # tar.gz archive with version in name
           mkdir -p /tmp/ostt-vulkan-archive
           cp target/dist/ostt /tmp/ostt-vulkan-archive/ostt
-          tar -czf ostt-x86_64-unknown-linux-gnu-vulkan.tar.gz \
+          tar -czf "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz" \
             -C /tmp/ostt-vulkan-archive ostt
-      - name: Create checksums
-        run: |
+          sha256sum "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz" \
+            > "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz.sha256"
+          # .deb and .rpm checksums (already versioned by cargo-deb / cargo-generate-rpm)
           cd target/debian
-          sha256sum ostt-vulkan_latest_amd64.deb > ostt-vulkan_latest_amd64.deb.sha256
+          sha256sum ostt-vulkan_*.deb > "$(ls ostt-vulkan_*.deb).sha256"
           cd ../generate-rpm
-          sha256sum ostt-vulkan-latest.x86_64.rpm > ostt-vulkan-latest.x86_64.rpm.sha256
-          cd ../..
-          sha256sum ostt-x86_64-unknown-linux-gnu-vulkan.tar.gz \
-            > ostt-x86_64-unknown-linux-gnu-vulkan.tar.gz.sha256
+          sha256sum ostt-vulkan-*.rpm > "$(ls ostt-vulkan-*.rpm).sha256"
       - name: Upload Vulkan artifacts
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-build-linux-vulkan-amd64
           path: |
-            ostt-x86_64-unknown-linux-gnu-vulkan.tar.gz
-            ostt-x86_64-unknown-linux-gnu-vulkan.tar.gz.sha256
-            target/debian/ostt-vulkan_latest_amd64.deb
-            target/debian/ostt-vulkan_latest_amd64.deb.sha256
-            target/generate-rpm/ostt-vulkan-latest.x86_64.rpm
-            target/generate-rpm/ostt-vulkan-latest.x86_64.rpm.sha256
+            ostt-*-x86_64-unknown-linux-gnu-vulkan.tar.gz
+            ostt-*-x86_64-unknown-linux-gnu-vulkan.tar.gz.sha256
+            target/debian/ostt-vulkan_*.deb
+            target/debian/ostt-vulkan_*.deb.sha256
+            target/generate-rpm/ostt-vulkan-*.rpm
+            target/generate-rpm/ostt-vulkan-*.rpm.sha256
 
   # Determines if we should publish/announce
   host:

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,10 +73,17 @@ fn load_config() -> anyhow::Result<crate::config::OsttConfig> {
     })
 }
 
+#[cfg(feature = "whisper-vulkan")]
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-vulkan");
+#[cfg(feature = "whisper-cuda")]
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-cuda");
+#[cfg(not(any(feature = "whisper-vulkan", feature = "whisper-cuda")))]
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// A terminal-based speech-to-text recorder with real-time waveform visualization
 #[derive(Parser)]
 #[command(name = "ostt")]
-#[command(version)]
+#[command(version = VERSION)]
 #[command(about = "\n\n┏┓┏╋╋ \n┗┛┛┗┗")]
 #[command(
     long_about = "\n\n┏┓┏╋╋ \n┗┛┛┗┗\n\nA terminal-based speech-to-text recorder with real-time waveform visualization\nand automatic transcription support.\n\nDEFAULT COMMAND:\n    If no command is specified, 'record' is used by default.\n    Record options (-c, -o) can be used without explicitly saying 'record'.\n\nEXAMPLES:\n    # Record and pipe to other command (default stdout)\n    $ ostt | grep word\n    $ ostt record | grep word\n    \n    # Record and copy to clipboard\n    $ ostt -c\n    $ ostt record -c\n    $ ostt -m deepgram/nova-3 -c\n    \n    # Record and write to file\n    $ ostt -o output.txt\n    $ ostt record -o output.txt\n    \n    # Retry most recent recording and pipe output\n    $ ostt retry | wc -w\n    \n    # Retry recording #2 and copy to clipboard\n    $ ostt retry 2 -c\n    \n    # Transcribe a pre-recorded audio file\n    $ ostt transcribe recording.ogg\n    $ ostt transcribe recording.ogg -m openai/gpt-4o-transcribe\n    \n    # Transcribe and copy to clipboard\n    $ ostt transcribe voice-memo.mp3 -c\n    \n    # Set up authentication for cloud providers\n    $ ostt auth\n    \n    # Choose cloud or local transcription model\n    $ ostt model\n    \n    # View your transcription history\n    $ ostt history\n    \n    # Manage transcription keywords\n    $ ostt keyword\n\n    # Manage deterministic text replace rules\n    $ ostt replace\n    \n    # Edit configuration file\n    $ ostt config"

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -65,6 +65,8 @@ fn write_command(program: &str, args: &[&str], text: &str) -> anyhow::Result<()>
     let mut child = Command::new(program)
         .args(args)
         .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .with_context(|| format!("Failed to run {program}"))?;
     let mut stdin = child

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -204,7 +204,7 @@ fn paste_key_failure_message_for_context(
             message.push_str(MACOS_ACCESSIBILITY_REMEDIATION);
         }
         PasteKeyFailureContext::GnomeWayland => {
-            message.push_str("\nGNOME Wayland does not support OSTT's normal auto-paste methods for native Wayland apps.");
+            message.push_str("\nGNOME Wayland does not support wtype or xdotool for native Wayland apps. Install ydotool and start ydotoold to enable auto-paste.");
         }
         PasteKeyFailureContext::Other => {}
     }
@@ -366,6 +366,10 @@ fn send_linux_key(paste_key: &str) -> anyhow::Result<()> {
             Ok(()) => return Ok(()),
             Err(err) => tracing::debug!("Paste mode: wtype failed: {err}"),
         }
+        match send_ydotool_key(paste_key) {
+            Ok(()) => return Ok(()),
+            Err(err) => tracing::debug!("Paste mode: ydotool failed: {err}"),
+        }
     }
 
     send_xdotool_key(paste_key)
@@ -391,6 +395,21 @@ fn send_wtype_key(paste_key: &str) -> anyhow::Result<()> {
 
     tracing::debug!("Paste mode: running wtype {:?}", args);
     run_status(Command::new("wtype").args(args), "wtype")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn send_ydotool_key(paste_key: &str) -> anyhow::Result<()> {
+    let (modifiers, key) = parse_paste_key(paste_key)?;
+    let mut parts: Vec<String> = modifiers
+        .iter()
+        .map(|modifier| xdotool_modifier(modifier).map(str::to_string))
+        .collect::<anyhow::Result<_>>()?;
+    parts.push(linux_key_name(&key));
+    tracing::debug!("Paste mode: running ydotool key {}", parts.join("+"));
+    run_status(
+        Command::new("ydotool").args(["key", &parts.join("+")]),
+        "ydotool",
+    )
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/src/transcription/api/local.rs
+++ b/src/transcription/api/local.rs
@@ -72,6 +72,10 @@ pub(super) async fn transcribe(
     let model_path = resolve_installed_model_path(&config.model_id)?;
     let audio_samples = load_audio_for_whisper(audio_path)?;
     whisper_rs::install_logging_hooks();
+    tracing::info!(
+        "local transcription: loading model with {}",
+        crate::transcription::local_inference_backend()
+    );
 
     let text = tokio::task::spawn_blocking(move || {
         let model_path = model_path.to_string_lossy().into_owned();
@@ -80,7 +84,7 @@ pub(super) async fn transcribe(
         let ctx = WhisperContext::new_with_params(&model_path, WhisperContextParameters::default())
             .map_err(|err| ModelError::LoadFailed(err.to_string()))?;
         tracing::info!(
-            "local transcription backend: {}",
+            "local transcription: backend active: {}",
             crate::transcription::local_inference_backend_details()
         );
         let mut state = ctx

--- a/src/transcription/daemon.rs
+++ b/src/transcription/daemon.rs
@@ -89,7 +89,12 @@ pub async fn run(model_id: &str, idle_timeout_secs: Option<u64>) -> anyhow::Resu
     }
 
     // Load the model (expensive — this is the whole point of the daemon).
-    tracing::info!("daemon: loading model '{model_id}'");
+    whisper_rs::install_logging_hooks();
+    tracing::info!(
+        "daemon: loading model '{}' with {}",
+        model_id,
+        crate::transcription::local_inference_backend()
+    );
     let model_path = resolve_installed_model_path(model_id)?;
     let model_path_str = model_path
         .to_str()
@@ -103,7 +108,7 @@ pub async fn run(model_id: &str, idle_timeout_secs: Option<u64>) -> anyhow::Resu
     .await??;
 
     tracing::info!(
-        "daemon: local transcription backend: {}",
+        "daemon: backend active: {}",
         crate::transcription::local_inference_backend_details()
     );
 

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -198,12 +198,19 @@ fn local_gpu_devices() -> Vec<String> {
                 continue;
             }
 
-            let description = whisper_rs_sys::ggml_backend_dev_description(device);
-            if description.is_null() {
-                devices.push("unknown GPU".to_string());
-            } else {
-                devices.push(CStr::from_ptr(description).to_string_lossy().into_owned());
-            }
+            let name = {
+                let ptr = whisper_rs_sys::ggml_backend_dev_description(device);
+                if ptr.is_null() {
+                    "unknown GPU".to_string()
+                } else {
+                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+                }
+            };
+            let mut vram_free: usize = 0;
+            let mut vram_total: usize = 0;
+            whisper_rs_sys::ggml_backend_dev_memory(device, &mut vram_free, &mut vram_total);
+            let vram_mb = vram_total / (1024 * 1024);
+            devices.push(format!("{name} ({vram_mb} MB VRAM)"));
         }
 
         devices


### PR DESCRIPTION
## Summary

- **#78** — `ostt --version` now appends `-vulkan` or `-cuda` for GPU builds so users can identify which variant they have
- **#82** — Release asset filenames now include the version number (e.g. `ostt-0.0.21-x86_64-unknown-linux-gnu-vulkan.tar.gz`); the `latest` placeholder names are removed
- **#79** — Startup log lines now confirm which backend is being attempted before model load, and which GPU device (with VRAM) is active after load; `install_logging_hooks()` added to the daemon path so whisper.cpp's own backend selection messages appear in logs
- **#77** — `ydotool` added as a Wayland paste fallback between `wtype` and `xdotool`; works on GNOME Wayland and any other compositor where `wtype` is unsupported; no config required, detected automatically at runtime
- **#46** — xclip no longer prints "Waiting for selection requests" noise to the terminal; stdout/stderr are now redirected to null in the clipboard write path

## Closes

Closes #77
Closes #78
Closes #82
Closes #46
Closes #79 

## Thanks

- @HaleTom for #78, #79, and #82 
- @adarshmadrecha for #77
- @plittlefield for #46