### PR TITLE
Fix xclip hang on X11 when using -c flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ostt -c` no longer hangs indefinitely on X11 when using xclip. The `-quiet` flag prevented xclip from forking to the background, causing ostt to wait forever. Stdout/stderr were already suppressed via Rust's `Stdio::null()`, making `-quiet` redundant. Reported by @plittlefield in [#85](https://github.com/kristoferlund/ostt/issues/85).
+
 ## 0.0.23 - 2026-06-09
 
 ### Fixed

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -46,7 +46,7 @@ pub(crate) fn set_clipboard(text: &str) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        write_command("xclip", &["-selection", "clipboard", "-in", "-quiet"], text)
+        write_command("xclip", &["-selection", "clipboard", "-in"], text)
     }
 }
 


### PR DESCRIPTION
## Summary

- Removes the `-quiet` flag from the `xclip` invocation in `clipboard.rs`
- `Stdio::null()` already suppresses stdout/stderr, making `-quiet` redundant
- The `-quiet` flag prevented xclip from forking to the background, causing `ostt -c` to hang indefinitely on X11

Closes #85

Thanks to @plittlefield for diagnosing the root cause.