### PR TITLE
Auto-calibrating volume meter and recording visualization polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,14 +328,17 @@ jobs:
         run: cargo generate-rpm -s 'name = "ostt-cuda"'
       - name: Create versioned archive and checksums
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          # tar.gz archive with version in name
-          mkdir -p /tmp/ostt-cuda-archive
-          cp target/dist/ostt /tmp/ostt-cuda-archive/ostt
-          tar -czf "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz" \
-            -C /tmp/ostt-cuda-archive ostt
-          sha256sum "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz" \
-            > "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz.sha256"
+          # Only create a versioned tar.gz on tag pushes (GITHUB_REF_NAME is a version,
+          # not a PR merge ref like "84/merge" which contains a slash).
+          if [[ "$GITHUB_REF_NAME" != */* ]]; then
+            VERSION=${GITHUB_REF_NAME#v}
+            mkdir -p /tmp/ostt-cuda-archive
+            cp target/dist/ostt /tmp/ostt-cuda-archive/ostt
+            tar -czf "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz" \
+              -C /tmp/ostt-cuda-archive ostt
+            sha256sum "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz" \
+              > "ostt-${VERSION}-x86_64-unknown-linux-gnu-cuda.tar.gz.sha256"
+          fi
           # .deb and .rpm checksums (already versioned by cargo-deb / cargo-generate-rpm)
           cd target/debian
           sha256sum ostt-cuda_*.deb > "$(ls ostt-cuda_*.deb).sha256"
@@ -395,14 +398,17 @@ jobs:
         run: cargo generate-rpm -s 'name = "ostt-vulkan"'
       - name: Create versioned archive and checksums
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          # tar.gz archive with version in name
-          mkdir -p /tmp/ostt-vulkan-archive
-          cp target/dist/ostt /tmp/ostt-vulkan-archive/ostt
-          tar -czf "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz" \
-            -C /tmp/ostt-vulkan-archive ostt
-          sha256sum "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz" \
-            > "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz.sha256"
+          # Only create a versioned tar.gz on tag pushes (GITHUB_REF_NAME is a version,
+          # not a PR merge ref like "84/merge" which contains a slash).
+          if [[ "$GITHUB_REF_NAME" != */* ]]; then
+            VERSION=${GITHUB_REF_NAME#v}
+            mkdir -p /tmp/ostt-vulkan-archive
+            cp target/dist/ostt /tmp/ostt-vulkan-archive/ostt
+            tar -czf "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz" \
+              -C /tmp/ostt-vulkan-archive ostt
+            sha256sum "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz" \
+              > "ostt-${VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz.sha256"
+          fi
           # .deb and .rpm checksums (already versioned by cargo-deb / cargo-generate-rpm)
           cd target/debian
           sha256sum ostt-vulkan_*.deb > "$(ls ostt-vulkan_*.deb).sha256"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Audio capture now uses the system `default` input device by default instead of requiring a named device.
 - The volume meter now calibrates itself by default (`reference_level_db = "auto"`). The meter scale adapts to the observed speech level — fast attack, slow release — so metering works out of the box regardless of OS input gain, on macOS and Linux alike. Setting a numeric `reference_level_db` keeps the previous fixed-reference behavior.
 - The red peak indicator now means actual clipping (signal within 3 dB of full scale) when using auto mode, instead of crossing an arbitrary configurable level. When the signal clips, the entire recording footer lights up red for 1.5 seconds. `peak_volume_threshold` now only applies with a fixed reference level.
 - Simplified the recording footer: removed the red recording dot and the rapidly flickering instantaneous volume value, leaving the duration and the peak-hold percentage.
 - Polished the spectrum visualization: bars now rise instantly and fall with gravity, per-column peak caps sink slowly after loud moments, the spectrum is mirrored center-out so voice fundamentals sit in the middle of the screen, and the whole display dims while recording is paused.
+
+### Fixed
+
+- Clipping detection now checks the raw multi-channel input before mono downmixing, so single-channel microphones on multi-channel interfaces no longer hide true peaks.
 
 ## 0.0.24 - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The volume meter now calibrates itself by default (`reference_level_db = "auto"`). The meter scale adapts to the observed speech level — fast attack, slow release — so metering works out of the box regardless of OS input gain, on macOS and Linux alike. Setting a numeric `reference_level_db` keeps the previous fixed-reference behavior.
+- The red peak indicator now means actual clipping (signal within 3 dB of full scale) when using auto mode, instead of crossing an arbitrary configurable level. When the signal clips, the entire recording footer lights up red for 1.5 seconds. `peak_volume_threshold` now only applies with a fixed reference level.
+- Simplified the recording footer: removed the red recording dot and the rapidly flickering instantaneous volume value, leaving the duration and the peak-hold percentage.
+- Polished the spectrum visualization: bars now rise instantly and fall with gravity, per-column peak caps sink slowly after loud moments, the spectrum is mirrored center-out so voice fundamentals sit in the middle of the screen, and the whole display dims while recording is paused.
+
 ## 0.0.24 - 2026-06-09
 
 ### Fixed

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -12,20 +12,6 @@
 #
 # To see available devices, run: ostt list-devices
 device = "default"
-
-# Peak volume threshold for red indicator (0-100, percentage of reference level)
-# Default 90 means warn at 90% of reference_level_db (10% headroom before clipping)
-peak_volume_threshold = 90
-
-# Reference level in dBFS for 100% meter display
-# Set this to your audio card's maximum input level for accurate metering
-# Typical values:
-#   -6 dBFS: Very hot recording (near clipping)
-#  -12 dBFS: Hot recording (professional standard)
-#  -18 dBFS: Moderate recording level
-#  -20 dBFS: Conservative level (typical audio card max)
-reference_level_db = -20
-
 # Output audio format (uses ffmpeg for conversion)
 # Format: "codec [ffmpeg_options]"
 # All audio is saved mono with ffmpeg handling resampling/compression
@@ -39,56 +25,3 @@ reference_level_db = -20
 #
 # Add more formats as needed - ffmpeg handles the rest!
 output_format = "mp3 -ab 16k -ar 12000"
-
-[text]
-# Deterministic post-transcription replace rules.
-# Keywords help the model recognize terms; replace fixes final text casing,
-# acronyms, project names, and common misrecognitions.
-#
-# Examples:
-# [text.replace]
-# "ostt" = "OSTT"
-# "api" = "API"
-# "typescript" = "TypeScript"
-# "github" = "GitHub"
-
-[output.paste]
-# Paste mode copies the final text to the clipboard, sends this shortcut,
-# then restores the previous clipboard when enabled.
-# Defaults: macOS uses cmd+v, Omarchy uses shift+insert, other Linux uses ctrl+v.
-# Linux paste shortcuts vary by app and desktop; override paste_key when needed.
-paste_key = "ctrl+v"
-restore_clipboard = true
-restore_delay_ms = 750
-post_popup_delay_ms = 1000
-
-# Provider and per-model transcription params.
-# Provider params apply to all models for that provider. Model params override provider params.
-#
-# Examples:
-# [deepgram.params]
-# detect_language = true
-# smart_format = true
-#
-# [deepgram.nova-3.params]
-# detect_language = true
-# smart_format = true
-# keyterm = ["OSTT"]
-#
-# [berget."openai/whisper-large-v3".params]
-# language = "sv"
-#
-# Built-in local Whisper models use the whisper provider.
-# [whisper]
-# output_format = "pcm_s16le -ar 16000"
-#
-# [whisper.params]
-# language = "auto"
-# no_timestamps = true
-# no_context = true
-# temperature = 0.0
-# entropy_thold = 2.4
-# no_speech_thold = 0.6
-#
-# [whisper.turbo.params]
-# language = "sv"

--- a/environments/ostt.toml
+++ b/environments/ostt.toml
@@ -12,6 +12,7 @@
 #
 # To see available devices, run: ostt list-devices
 device = "default"
+
 # Output audio format (uses ffmpeg for conversion)
 # Format: "codec [ffmpeg_options]"
 # All audio is saved mono with ffmpeg handling resampling/compression

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -35,7 +35,7 @@ pub async fn handle_record(
 ) -> anyhow::Result<()> {
     tracing::info!("=== ostt Audio Recorder Started ===");
     tracing::info!(
-        "Configuration loaded: device={}, peak_threshold={}%, reference_level={}dBFS",
+        "Configuration loaded: device={}, peak_threshold={}%, reference_level={}",
         config.audio.device,
         config.audio.peak_volume_threshold,
         config.audio.reference_level_db

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -399,7 +399,7 @@ fn run_recording_loop(
                     tracing::debug!("Recording: {:.1}s recorded", duration_secs);
                 }
 
-                tui.render_waveform(&audio_recorder.samples())
+                tui.render_waveform(&audio_recorder.samples(), audio_recorder.take_true_peak())
                     .map_err(|e| anyhow::anyhow!(e.to_string()))
                     .context("failed to render recording waveform")?;
             }
@@ -408,7 +408,7 @@ fn run_recording_loop(
             RecordingCommand::TogglePause => {
                 audio_recorder.toggle_pause();
                 tui.is_paused = audio_recorder.is_paused();
-                tui.render_waveform(&audio_recorder.samples())
+                tui.render_waveform(&audio_recorder.samples(), audio_recorder.take_true_peak())
                     .map_err(|e| anyhow::anyhow!(e.to_string()))
                     .context("failed to render recording waveform")?;
             }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -41,6 +41,7 @@ pub struct AudioConfig {
     /// - "default" for system default device
     /// - numeric index (0, 1, 2, etc.) from `ostt config list-devices`
     /// - device name from `ostt config list-devices`
+    #[serde(default = "default_device")]
     pub device: String,
     /// Peak volume threshold for visual indicator (0-100, percentage of reference level).
     /// Only used with a fixed reference level; in "auto" mode the red indicator
@@ -57,6 +58,10 @@ pub struct AudioConfig {
     /// Visualization type: "spectrum" (frequency-based) or "waveform" (time-based amplitude)
     #[serde(default)]
     pub visualization: VisualizationType,
+}
+
+fn default_device() -> String {
+    "default".to_string()
 }
 
 fn default_output_format() -> String {

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -42,12 +42,15 @@ pub struct AudioConfig {
     /// - numeric index (0, 1, 2, etc.) from `ostt config list-devices`
     /// - device name from `ostt config list-devices`
     pub device: String,
-    /// Peak volume threshold for visual indicator (0-100, percentage of reference level)
+    /// Peak volume threshold for visual indicator (0-100, percentage of reference level).
+    /// Only used with a fixed reference level; in "auto" mode the red indicator
+    /// means actual clipping.
     #[serde(default = "default_peak_volume_threshold")]
     pub peak_volume_threshold: u8,
-    /// Reference level in dBFS for 100% meter display (typical: -20 to -6 dBFS)
+    /// Reference level for 100% meter display: "auto" (adapt to the observed
+    /// speech level, default) or a fixed dBFS value (typical: -20 to -6)
     #[serde(default = "default_reference_level_db")]
-    pub reference_level_db: i8,
+    pub reference_level_db: ReferenceLevel,
     /// Output audio format string: "codec [ffmpeg_options]" (e.g., "mp3 -ab 16k -ar 12000")
     #[serde(default = "default_output_format")]
     pub output_format: String,
@@ -70,8 +73,56 @@ fn default_peak_volume_threshold() -> u8 {
     90
 }
 
-fn default_reference_level_db() -> i8 {
-    -20
+fn default_reference_level_db() -> ReferenceLevel {
+    ReferenceLevel::Auto
+}
+
+/// Reference level for the volume meter: adaptive or a fixed dBFS value.
+///
+/// Serialized as the string `"auto"` or a plain integer, so existing configs
+/// with `reference_level_db = -20` keep working.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferenceLevel {
+    /// Adapt the meter scale to the observed speech level (default)
+    Auto,
+    /// Fixed reference in dBFS
+    Db(i8),
+}
+
+impl Serialize for ReferenceLevel {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ReferenceLevel::Auto => serializer.serialize_str("auto"),
+            ReferenceLevel::Db(v) => serializer.serialize_i8(*v),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ReferenceLevel {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Db(i8),
+            Text(String),
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::Db(v) => Ok(ReferenceLevel::Db(v)),
+            Raw::Text(s) if s.eq_ignore_ascii_case("auto") => Ok(ReferenceLevel::Auto),
+            Raw::Text(s) => Err(serde::de::Error::custom(format!(
+                "invalid reference_level_db '{s}': expected \"auto\" or a dBFS number"
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for ReferenceLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReferenceLevel::Auto => write!(f, "auto"),
+            ReferenceLevel::Db(v) => write!(f, "{v} dBFS"),
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -1305,6 +1356,23 @@ mod tests {
 
     fn parse_input(toml_str: &str) -> Result<ActionInput, toml::de::Error> {
         toml::from_str(toml_str)
+    }
+
+    #[test]
+    fn reference_level_parses_auto_numeric_and_default() {
+        let auto: AudioConfig =
+            toml::from_str("device = \"default\"\nreference_level_db = \"auto\"").unwrap();
+        assert_eq!(auto.reference_level_db, ReferenceLevel::Auto);
+
+        let fixed: AudioConfig =
+            toml::from_str("device = \"default\"\nreference_level_db = -18").unwrap();
+        assert_eq!(fixed.reference_level_db, ReferenceLevel::Db(-18));
+
+        let missing: AudioConfig = toml::from_str("device = \"default\"").unwrap();
+        assert_eq!(missing.reference_level_db, ReferenceLevel::Auto);
+
+        let invalid = toml::from_str::<AudioConfig>("device = \"default\"\nreference_level_db = \"loud\"");
+        assert!(invalid.is_err());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use file::{
 pub use file::{
     AudioConfig, ModelOptionValue, OsttConfig, OutputConfig, ParamsConfig, PasteConfig,
     PopupConfig, ProviderConfig, ProviderConfigs, ProviderModelConfig, ProviderSettings,
-    TextConfig, TranscriptionSelectionConfig, VisualizationType,
+    ReferenceLevel, TextConfig, TranscriptionSelectionConfig, VisualizationType,
 };
 pub use secrets::{
     clear_api_key, clear_selected_model, get_api_key, get_authorized_providers, get_selected_model,

--- a/src/recording/audio.rs
+++ b/src/recording/audio.rs
@@ -12,6 +12,7 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use hound::WavWriter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[cfg(target_os = "linux")]
@@ -32,6 +33,10 @@ pub struct AudioRecorder {
     sample_rate: u32,
     /// Recorded audio samples (i16 PCM mono)
     samples: Arc<Mutex<Vec<i16>>>,
+    /// Highest absolute raw sample seen across all channels since the last read.
+    /// Used for clipping detection on the un-downmixed signal, so a mono mic on
+    /// a single channel of a multi-channel device is still detected as clipping.
+    true_peak: Arc<AtomicU16>,
     /// Active audio input stream (kept alive during recording)
     stream: Option<cpal::Stream>,
     /// Number of channels in device's native format
@@ -49,6 +54,7 @@ impl AudioRecorder {
         Self {
             sample_rate: 0,
             samples: Arc::new(Mutex::new(Vec::new())),
+            true_peak: Arc::new(AtomicU16::new(0)),
             stream: None,
             device_channels: 1,
             is_paused: Arc::new(Mutex::new(false)),
@@ -100,6 +106,7 @@ impl AudioRecorder {
         // Set up audio callback with cloned Arc references
         let samples_arc = Arc::clone(&self.samples);
         let pause_arc = Arc::clone(&self.is_paused);
+        let true_peak_arc = Arc::clone(&self.true_peak);
         let callback_channels = num_channels;
 
         let stream = device
@@ -108,6 +115,10 @@ impl AudioRecorder {
                 move |data: &[i16], _: &cpal::InputCallbackInfo| {
                     let is_paused = *pause_arc.lock().unwrap();
                     if !is_paused {
+                        // Track the peak of the raw, un-downmixed samples so a
+                        // hot single channel still registers as clipping.
+                        let peak = data.iter().map(|&s| s.unsigned_abs()).max().unwrap_or(0);
+                        true_peak_arc.fetch_max(peak, Ordering::Relaxed);
                         Self::handle_audio_callback(data, &samples_arc, callback_channels);
                     }
                 },
@@ -320,6 +331,13 @@ impl AudioRecorder {
     /// Returns the number of recorded samples.
     pub fn sample_count(&self) -> usize {
         self.samples.lock().unwrap().len()
+    }
+
+    /// Returns the highest absolute raw sample seen across all channels since
+    /// the last call, resetting the running peak to zero. Drives the clipping
+    /// indicator from the un-downmixed signal.
+    pub fn take_true_peak(&self) -> u16 {
+        self.true_peak.swap(0, Ordering::Relaxed)
     }
 
     /// Returns the actual sample rate of the recording.

--- a/src/recording/tui.rs
+++ b/src/recording/tui.rs
@@ -187,8 +187,12 @@ impl RecordingTui {
     ///
     /// # Errors
     /// - If terminal rendering fails
-    pub fn render_waveform(&mut self, samples: &[i16]) -> Result<(), Box<dyn Error>> {
-        let current_volume = self.calculate_volume(samples);
+    pub fn render_waveform(
+        &mut self,
+        samples: &[i16],
+        raw_true_peak: u16,
+    ) -> Result<(), Box<dyn Error>> {
+        let current_volume = self.calculate_volume(samples, raw_true_peak);
         let reference_db = self.effective_reference_db();
 
         if !self.is_paused && self.last_sample_time.elapsed() >= self.sample_interval {
@@ -411,7 +415,7 @@ impl RecordingTui {
     /// Converts RMS (Root Mean Square) audio samples to dBFS and normalizes to 0-100% scale
     /// based on the configured reference level. Also tracks the maximum volume seen in the
     /// last 3 seconds for the peak indicator.
-    fn calculate_volume(&mut self, samples: &[i16]) -> u8 {
+    fn calculate_volume(&mut self, samples: &[i16], raw_true_peak: u16) -> u8 {
         if samples.is_empty() {
             return 0;
         }
@@ -430,14 +434,11 @@ impl RecordingTui {
             -160.0
         };
 
-        // True peak of the window, for the absolute clip indicator
-        let peak_abs = recent_samples
-            .iter()
-            .map(|&x| i32::from(x).abs())
-            .max()
-            .unwrap_or(0);
-        if !self.is_paused && peak_abs > 0 {
-            let true_peak_db = 20.0 * (peak_abs as f32 / 32767.0).log10();
+        // Absolute clip indicator: use the raw, un-downmixed true peak supplied
+        // by the recorder. A mono mic on one channel of a multi-channel device
+        // would otherwise be attenuated by the mono averaging and never clip.
+        if !self.is_paused && raw_true_peak > 0 {
+            let true_peak_db = 20.0 * (f32::from(raw_true_peak) / 32767.0).log10();
             if true_peak_db >= CLIP_PEAK_DB {
                 self.last_clip_time = Some(std::time::Instant::now());
             }

--- a/src/recording/tui.rs
+++ b/src/recording/tui.rs
@@ -16,15 +16,37 @@ use ratatui::{
 use std::error::Error;
 use std::io::{stdout, Stdout};
 
-use crate::config::VisualizationType;
 use crate::config::{file::ProcessAction, OsttConfig};
+use crate::config::{ReferenceLevel, VisualizationType};
 use crate::process::process_view::{handle_picker_event, render_process_view, PickerResult};
 use crate::transcription::TranscriptionAnimation;
 use crate::ui::is_cancel_key;
 
-use super::visualizations::{resize_waveform, update_waveform, SpectrumAnalyzer};
+use super::visualizations::{center_out_layout, resize_waveform, update_waveform, SpectrumAnalyzer};
 
 const PENDING_AUDIO_SAMPLE_RATE: u32 = 48_000;
+
+/// How fast peak caps sink, in display units (0-100) per rendered frame
+/// (~20 fps → full-scale fall in ~3.3 seconds).
+const CAP_FALL_PER_FRAME: f32 = 1.5;
+
+/// True-peak level treated as clipping for the red indicator (auto mode).
+/// Absolute, so it needs no per-machine calibration.
+const CLIP_PEAK_DB: f32 = -3.0;
+
+/// How long the clip indicator stays lit after a clip is detected.
+const CLIP_HOLD: std::time::Duration = std::time::Duration::from_millis(1500);
+
+/// Starting point for the adaptive reference level before any speech is heard.
+const ADAPTIVE_REF_INITIAL_DB: f32 = -24.0;
+
+/// Bounds for the adaptive reference level.
+const ADAPTIVE_REF_MIN_DB: f32 = -35.0;
+const ADAPTIVE_REF_MAX_DB: f32 = -6.0;
+
+/// Slow release rate per rendered frame (~0.5 dB/s at 20 fps), applied while
+/// signal is present but below the current reference.
+const ADAPTIVE_REF_RELEASE_PER_FRAME: f32 = 0.025;
 
 /// User input command during recording.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,14 +70,18 @@ pub struct RecordingTui {
     display_data: Vec<u64>,
     last_sample_time: std::time::Instant,
     sample_interval: std::time::Duration,
-    last_peak: u8,
     terminal_width: usize,
     sample_rate: u32,
     recording_start_time: std::time::Instant,
     peak_hold: u8,
     peak_hold_time: std::time::Instant,
     peak_volume_threshold: u8,
-    reference_level_db: i8,
+    /// Configured reference level: auto (adaptive) or fixed dBFS
+    reference_level: ReferenceLevel,
+    /// Current adaptive reference in dBFS (used in auto mode)
+    adaptive_ref_db: f32,
+    /// When clipping was last detected (drives the red indicator in auto mode)
+    last_clip_time: Option<std::time::Instant>,
     /// Whether recording is currently paused
     pub is_paused: bool,
     /// Total time paused (accumulated when paused)
@@ -66,6 +92,8 @@ pub struct RecordingTui {
     visualization_type: VisualizationType,
     /// Spectrum analyzer (used when visualization_type is Spectrum)
     spectrum_analyzer: Option<SpectrumAnalyzer>,
+    /// Per-column peak cap positions (spectrum mode), sinking slowly over time
+    peak_caps: Vec<f32>,
     cleaned_up: bool,
 }
 
@@ -103,19 +131,21 @@ impl RecordingTui {
             display_data,
             last_sample_time: now,
             sample_interval,
-            last_peak: 0,
             terminal_width,
             sample_rate,
             recording_start_time: now,
             peak_hold: 0,
             peak_hold_time: now,
             peak_volume_threshold: config.audio.peak_volume_threshold,
-            reference_level_db: config.audio.reference_level_db,
+            reference_level: config.audio.reference_level_db,
+            adaptive_ref_db: ADAPTIVE_REF_INITIAL_DB,
+            last_clip_time: None,
             is_paused: false,
             pause_duration: std::time::Duration::ZERO,
             pause_start_time: None,
             visualization_type: config.audio.visualization,
             spectrum_analyzer,
+            peak_caps: Vec::new(),
             cleaned_up: false,
         })
     }
@@ -135,6 +165,22 @@ impl RecordingTui {
         self.pause_duration = std::time::Duration::ZERO;
         self.pause_start_time = None;
         self.is_paused = false;
+        self.adaptive_ref_db = ADAPTIVE_REF_INITIAL_DB;
+        self.last_clip_time = None;
+    }
+
+    /// Returns the reference level (dBFS) currently used for meter scaling.
+    fn effective_reference_db(&self) -> f32 {
+        match self.reference_level {
+            ReferenceLevel::Db(v) => f32::from(v),
+            ReferenceLevel::Auto => self.adaptive_ref_db,
+        }
+    }
+
+    /// Returns true if clipping was detected recently (auto mode indicator).
+    fn is_clipping(&self) -> bool {
+        self.last_clip_time
+            .is_some_and(|t| t.elapsed() < CLIP_HOLD)
     }
 
     /// Renders the visualization with current volume and recording duration.
@@ -143,12 +189,13 @@ impl RecordingTui {
     /// - If terminal rendering fails
     pub fn render_waveform(&mut self, samples: &[i16]) -> Result<(), Box<dyn Error>> {
         let current_volume = self.calculate_volume(samples);
+        let reference_db = self.effective_reference_db();
 
         if !self.is_paused && self.last_sample_time.elapsed() >= self.sample_interval {
             match self.visualization_type {
                 VisualizationType::Spectrum => {
                     if let Some(analyzer) = &mut self.spectrum_analyzer {
-                        analyzer.update(samples, self.sample_rate, self.reference_level_db);
+                        analyzer.update(samples, self.sample_rate, reference_db);
                         self.display_data = analyzer.data().to_vec();
                     }
                 }
@@ -169,12 +216,7 @@ impl RecordingTui {
             match self.visualization_type {
                 VisualizationType::Spectrum => {
                     if let Some(analyzer) = &mut self.spectrum_analyzer {
-                        analyzer.resize(
-                            current_width,
-                            samples,
-                            self.sample_rate,
-                            self.reference_level_db,
-                        );
+                        analyzer.resize(current_width, samples, self.sample_rate, reference_db);
                         self.display_data = analyzer.data().to_vec();
                     }
                 }
@@ -187,9 +229,54 @@ impl RecordingTui {
         // Pre-calculate values to avoid borrow checker issues in closure
         let is_paused = self.is_paused;
         let peak_hold = self.peak_hold;
-        let last_peak = self.last_peak;
-        let peak_volume_threshold = self.peak_volume_threshold;
         let recording_duration = self.get_recording_duration();
+
+        // Auto mode: red means actual clipping (absolute, no calibration).
+        // Fixed mode: red means exceeding the configured threshold.
+        let peak_alert = !is_paused
+            && match self.reference_level {
+                ReferenceLevel::Auto => self.is_clipping(),
+                ReferenceLevel::Db(_) => peak_hold >= self.peak_volume_threshold,
+            };
+
+        // Spectrum mode renders center-out: low frequencies in the middle,
+        // highs mirrored toward both edges. Sized to the padded content width
+        // so the mirror axis lands on the visual center of the screen.
+        let content_width = current_width.saturating_sub(4);
+        let render_data: Vec<u64> = match self.visualization_type {
+            VisualizationType::Spectrum => center_out_layout(&self.display_data, content_width),
+            VisualizationType::Waveform => self.display_data.clone(),
+        };
+
+        // Peak caps: hold each column's recent maximum and let it sink slowly
+        let show_caps = self.visualization_type == VisualizationType::Spectrum;
+        if show_caps {
+            if self.peak_caps.len() != render_data.len() {
+                self.peak_caps = vec![0.0; render_data.len()];
+            }
+            if !is_paused {
+                for (cap, &v) in self.peak_caps.iter_mut().zip(render_data.iter()) {
+                    *cap = (*cap - CAP_FALL_PER_FRAME).max(v as f32);
+                }
+            }
+        }
+
+        // Dim the whole visualization while paused so the state is obvious
+        let (viz_fg, mirror_bg, footer_fg, cap_fg) = if is_paused {
+            (
+                Color::Rgb(98, 110, 113),
+                Color::Rgb(88, 99, 102),
+                Color::Rgb(98, 110, 113),
+                Color::Rgb(120, 127, 125),
+            )
+        } else {
+            (
+                Color::Rgb(206, 224, 220),
+                Color::Rgb(185, 207, 212),
+                Color::Rgb(185, 207, 212),
+                Color::Rgb(240, 250, 246),
+            )
+        };
 
         self.terminal.draw(|frame| {
             let area = frame.area();
@@ -226,15 +313,36 @@ impl RecordingTui {
             };
 
             let top_sparkline = Sparkline::default()
-                .data(&self.display_data)
+                .data(&render_data)
                 .max(100)
-                .style(
-                    Style::default()
-                        .bg(Color::Rgb(0, 0, 0))
-                        .fg(Color::Rgb(206, 224, 220)),
-                );
+                .style(Style::default().bg(Color::Rgb(0, 0, 0)).fg(viz_fg));
 
             frame.render_widget(top_sparkline, top_area);
+
+            // Peak caps: a thin marker resting just above each column's bar
+            if show_caps {
+                let max_rows = i32::from(top_area.height);
+                let buf = frame.buffer_mut();
+                for (i, &cap) in self.peak_caps.iter().enumerate() {
+                    if i >= top_area.width as usize {
+                        break;
+                    }
+                    let cap_row = ((cap / 100.0) * (max_rows * 8) as f32) as i32 / 8;
+                    let bar_row = render_data[i] as i32 * max_rows * 8 / 100 / 8;
+                    // Only draw while the cap floats above the bar's top cell,
+                    // so it never clobbers the bar's partial block glyph
+                    if cap_row > bar_row && cap_row < max_rows {
+                        let x = top_area.x + i as u16;
+                        let y = top_area.y + top_area.height - 1 - cap_row as u16;
+                        buf.set_string(
+                            x,
+                            y,
+                            "▁",
+                            Style::default().fg(cap_fg).bg(Color::Rgb(0, 0, 0)),
+                        );
+                    }
+                }
+            }
 
             let bottom_area = Rect {
                 x: content_area.x,
@@ -243,17 +351,15 @@ impl RecordingTui {
                 height: content_area.height.saturating_sub(top_area_height),
             };
 
-            let inverted_data: Vec<u64> = self
-                .display_data
+            let inverted_data: Vec<u64> = render_data
                 .iter()
                 .map(|&v| 100_u64.saturating_sub(v))
                 .collect();
 
-            let bottom_sparkline = Sparkline::default().data(&inverted_data).max(100).style(
-                Style::default()
-                    .bg(Color::Rgb(185, 207, 212))
-                    .fg(Color::Rgb(0, 0, 0)),
-            );
+            let bottom_sparkline = Sparkline::default()
+                .data(&inverted_data)
+                .max(100)
+                .style(Style::default().bg(mirror_bg).fg(Color::Rgb(0, 0, 0)));
 
             frame.render_widget(bottom_sparkline, bottom_area);
 
@@ -264,51 +370,35 @@ impl RecordingTui {
                 height: footer_height,
             };
 
-            // When paused, show zeros for meters
-            let (display_peak, display_volume) = if is_paused {
-                (0u8, 0u8)
-            } else {
-                (peak_hold, last_peak)
-            };
+            // When paused, show zero for the peak meter
+            let display_peak = if is_paused { 0u8 } else { peak_hold };
 
-            let peak_style = if display_peak >= peak_volume_threshold {
+            // The whole footer lights up red when the signal peaks
+            let footer_style = if peak_alert {
                 Style::default()
                     .bg(Color::Red)
                     .fg(Color::Rgb(255, 255, 255))
             } else {
-                Style::default()
+                Style::default().fg(footer_fg).bg(Color::Rgb(0, 0, 0))
             };
 
             let duration_secs = recording_duration.as_secs();
             let minutes = duration_secs / 60;
             let secs = duration_secs % 60;
-            let duration_span = ratatui::text::Span::raw(format!("{minutes}:{secs:02}"));
 
-            let peak_span = ratatui::text::Span::styled(format!("{display_peak}%"), peak_style);
+            let mut spans = Vec::new();
+            if is_paused {
+                spans.push(ratatui::text::Span::styled(
+                    "⏸ ",
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
+            spans.push(ratatui::text::Span::raw(format!(
+                "{minutes}:{secs:02} / {display_peak}%"
+            )));
 
-            let vol_span = ratatui::text::Span::raw(format!("{display_volume}%"));
-
-            // Show pause symbol instead of red dot when paused
-            let indicator = if is_paused {
-                ratatui::text::Span::styled("⏸ ", Style::default().fg(Color::Yellow))
-            } else {
-                ratatui::text::Span::styled("● ", Style::default().fg(Color::Red))
-            };
-
-            let help_text = ratatui::text::Line::from(vec![
-                indicator,
-                duration_span,
-                ratatui::text::Span::raw(" / "),
-                vol_span,
-                ratatui::text::Span::raw(" / "),
-                peak_span,
-            ]);
-
-            let footer = ratatui::widgets::Paragraph::new(help_text).style(
-                Style::default()
-                    .fg(Color::Rgb(185, 207, 212))
-                    .bg(Color::Rgb(0, 0, 0)),
-            );
+            let footer = ratatui::widgets::Paragraph::new(ratatui::text::Line::from(spans))
+                .style(footer_style);
 
             frame.render_widget(footer, footer_area);
         })?;
@@ -340,10 +430,35 @@ impl RecordingTui {
             -160.0
         };
 
-        let min_db = self.reference_level_db as f32 - 40.0;
-        let normalized = ((db_fs - min_db) / 40.0 * 100.0).clamp(4.0, 100.0) as u8;
+        // True peak of the window, for the absolute clip indicator
+        let peak_abs = recent_samples
+            .iter()
+            .map(|&x| i32::from(x).abs())
+            .max()
+            .unwrap_or(0);
+        if !self.is_paused && peak_abs > 0 {
+            let true_peak_db = 20.0 * (peak_abs as f32 / 32767.0).log10();
+            if true_peak_db >= CLIP_PEAK_DB {
+                self.last_clip_time = Some(std::time::Instant::now());
+            }
+        }
 
-        self.last_peak = normalized;
+        // Auto mode: adapt the reference toward the observed speech level —
+        // fast attack when the signal exceeds it, slow release while signal
+        // is present but quieter, hold during silence
+        if self.reference_level == ReferenceLevel::Auto && !self.is_paused {
+            if db_fs > self.adaptive_ref_db {
+                self.adaptive_ref_db += (db_fs - self.adaptive_ref_db) * 0.5;
+            } else if db_fs > self.adaptive_ref_db - 25.0 {
+                self.adaptive_ref_db -= ADAPTIVE_REF_RELEASE_PER_FRAME;
+            }
+            self.adaptive_ref_db = self
+                .adaptive_ref_db
+                .clamp(ADAPTIVE_REF_MIN_DB, ADAPTIVE_REF_MAX_DB);
+        }
+
+        let min_db = self.effective_reference_db() - 40.0;
+        let normalized = ((db_fs - min_db) / 40.0 * 100.0).clamp(4.0, 100.0) as u8;
 
         if normalized > self.peak_hold || self.peak_hold_time.elapsed().as_secs() >= 3 {
             self.peak_hold = normalized;

--- a/src/recording/visualizations/mod.rs
+++ b/src/recording/visualizations/mod.rs
@@ -6,5 +6,5 @@
 pub mod spectrum;
 pub mod waveform;
 
-pub use spectrum::SpectrumAnalyzer;
+pub use spectrum::{center_out_layout, SpectrumAnalyzer};
 pub use waveform::{resize_waveform, update_waveform};

--- a/src/recording/visualizations/spectrum.rs
+++ b/src/recording/visualizations/spectrum.rs
@@ -22,7 +22,11 @@ impl SpectrumAnalyzer {
     }
 
     /// Updates spectrum with new samples, applying smoothing.
-    pub fn update(&mut self, samples: &[i16], sample_rate: u32, reference_level_db: i8) {
+    ///
+    /// Bars attack instantly on rising energy but fall gradually (~15% per
+    /// update), giving the classic analyzer "gravity" feel instead of
+    /// symmetric jitter.
+    pub fn update(&mut self, samples: &[i16], sample_rate: u32, reference_level_db: f32) {
         let new_bins = calculate_spectrum(
             samples,
             sample_rate,
@@ -31,9 +35,12 @@ impl SpectrumAnalyzer {
             &mut self.fft_planner,
         );
 
-        // Apply moving average smoothing to reduce visual jitter
         for (old_val, new_val) in self.display_data.iter_mut().zip(new_bins.iter()) {
-            *old_val = (*old_val + *new_val) / 2;
+            if *new_val >= *old_val {
+                *old_val = *new_val;
+            } else {
+                *old_val = (*old_val * 85 / 100).max(*new_val);
+            }
         }
     }
 
@@ -43,7 +50,7 @@ impl SpectrumAnalyzer {
         new_width: usize,
         samples: &[i16],
         sample_rate: u32,
-        reference_level_db: i8,
+        reference_level_db: f32,
     ) {
         self.num_bins = new_width;
         if !samples.is_empty() {
@@ -65,6 +72,25 @@ impl SpectrumAnalyzer {
     }
 }
 
+/// Remaps spectrum bins to a center-out layout for display.
+///
+/// Low frequencies land in the middle of the display and high frequencies
+/// mirror out toward both edges, so the energetic voice fundamentals sit in
+/// the visual center.
+pub fn center_out_layout(data: &[u64], width: usize) -> Vec<u64> {
+    if data.is_empty() || width == 0 {
+        return vec![0; width];
+    }
+    let half = width as f32 / 2.0;
+    (0..width)
+        .map(|i| {
+            let dist = ((i as f32 + 0.5) - half).abs() / half;
+            let idx = (dist * (data.len() - 1) as f32).round() as usize;
+            data[idx.min(data.len() - 1)]
+        })
+        .collect()
+}
+
 /// Calculates frequency spectrum from audio samples using FFT.
 ///
 /// Returns magnitudes normalized to 0-100, matching volume meter scaling.
@@ -80,7 +106,7 @@ pub fn calculate_spectrum(
     samples: &[i16],
     sample_rate: u32,
     num_bins: usize,
-    reference_level_db: i8,
+    reference_level_db: f32,
     fft_planner: &mut FftPlanner<f32>,
 ) -> Vec<u64> {
     if samples.is_empty() {
@@ -117,7 +143,7 @@ pub fn calculate_spectrum(
     let min_bin = (min_freq / freq_resolution) as usize;
     let max_bin = (max_freq / freq_resolution).min((fft_size / 2) as f32) as usize;
 
-    let noise_gate_db = reference_level_db as f32 - 35.0;
+    let noise_gate_db = reference_level_db - 35.0;
 
     // Distribute FFT bins evenly across display width
     let useful_bins = max_bin - min_bin;
@@ -158,7 +184,7 @@ pub fn calculate_spectrum(
             if adjusted_db < noise_gate_db {
                 *result_bin = 0;
             } else {
-                let db_range = reference_level_db as f32 - noise_gate_db;
+                let db_range = reference_level_db - noise_gate_db;
                 let normalized =
                     ((adjusted_db - noise_gate_db) / db_range * 100.0).clamp(0.0, 100.0);
                 *result_bin = normalized as u64;


### PR DESCRIPTION
## Summary

Removes the need to tune `reference_level_db` / `peak_volume_threshold` per machine — metering now works out of the box like an OBS-style mixer, and the spectrum visualization gets a round of motion polish.

### Auto-calibrating meter (new default)

- `reference_level_db` now accepts `"auto"` and defaults to it. The meter scale adapts to the observed speech level with a fast attack and slow (~0.5 dB/s) release, clamped to -35..-6 dBFS, and holds during silence. Works the same regardless of OS input gain (fixes the Linux "peaks too early" behavior).
- In auto mode, the red indicator means **actual clipping**: true sample peak within 3 dB of full scale. It's absolute, so it needs no calibration. When the signal clips, the entire footer lights up red for 1.5 s.
- Backwards compatible: numeric `reference_level_db` values parse as before and keep the exact old fixed-reference behavior, including the `peak_volume_threshold`-based indicator.

### Recording visualization polish

- Spectrum bars rise instantly and fall with gravity (~15% per update) instead of symmetric jitter.
- Per-column peak caps hold recent maxima and sink slowly.
- Center-out spectrum layout: voice fundamentals in the middle, highs mirrored toward the edges (also fixes 4 columns being silently clipped off the right edge).
- The whole visualization dims while paused, so the paused state is visible at a glance.
- Simplified footer: duration + peak-hold percentage; removed the red recording dot and the flickering instantaneous volume value.

## Test plan

- [x] `cargo test --lib` — 229 passed, including new config parsing tests for `"auto"` / numeric / missing / invalid values
- [x] `cargo clippy --all-targets` — no new warnings
- [x] Manual: record on Linux with hot input gain — red footer only on genuine clipping
- [x ] Manual: existing config with numeric `reference_level_db` behaves as before
